### PR TITLE
[#11] Checking for entries in destination subpaths in `copy` command

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -148,6 +148,8 @@ main = do
                 let header = "The following entries cannot be copied because a directory already exists at the destination."
                 let errorMsgs = NE.toList paths <&> \(from, to) -> "Cannot copy '" +| from |+ "' to '" +| to |+ "'."
                 printError $ unlinesF @_ @Builder $ header : "" : errorMsgs
+              CPRDestinationHasEntry entry -> printError $
+                "The following entries cannot be copied because a destination directory has an entry '" +| build entry |+ "' in it's subpath."
               CPREntryAlreadyExists paths -> do
                 let header = unlinesF @_ @Builder
                       [ "The following entries cannot be copied because an entry already exists at the destination."

--- a/lib/Backend/Commands.hs
+++ b/lib/Backend/Commands.hs
@@ -18,15 +18,10 @@ import Data.Time.Calendar.Compat (pattern YearMonthDay)
 import Data.Time.Calendar.Month.Compat (pattern MonthDay)
 import Control.Lens (view)
 import Polysemy.Error (throw, Error)
-import Control.Monad.Extra (whenM, whenJust)
-import Data.List.NonEmpty (NonEmpty)
+import Control.Monad.Extra (whenM)
 import qualified Data.List.NonEmpty as NE
 import Data.Set (Set)
 import qualified Data.Set as Set
-import qualified Data.List as List
-import Polysemy.Error (throw, Error, runError)
-import Control.Monad.Extra (whenM)
-import qualified Data.List.NonEmpty as NE
 
 import Backend (BackendEffect, listSecrets, readSecret, writeSecret, deleteSecret)
 import Entry (Entry, Field, FieldKey, value, fields, dateModified, newEntry, newField, visibility, FieldVisibility(..), EntryTag, path)
@@ -38,7 +33,8 @@ import qualified Coffer.Path as Path
 import Error (CofferError(..))
 import Coffer.Util (catchAndReturn)
 import Data.Either (rights)
-import Data.List (inits)
+import Validation (Validation (Success, Failure))
+import Data.Bifunctor (Bifunctor (first))
 
 runCommand
   :: (Member BackendEffect r, Member (Embed IO) r, Member (Error CofferError) r)
@@ -96,39 +92,11 @@ createCmd (CreateOptions entryPath _edit force tags fields privateFields) = do
       & E.fields .~ HashMap.fromList allFields
       & E.tags .~ tags
 
-  whenM (pathIsDirectory entryPath) do
-    throw $ CRDirectoryAlreadyExists entryPath
-
-  checkForEntriesInEntryPath entryPath
-
-  when (not force) do
-    whenM (pathIsEntry entryPath) do
-      throw $ CREntryAlreadyExists entryPath
-
-  void $ writeSecret entry
-  pure $ CRSuccess entry
-
-  where
-    -- | When attempting to create an entry at, e.g., @/a/b/c@, the directories
-    -- @/a@ and @/a/b@ will be implicitly created.
-    --
-    -- This function checks whether those paths are already
-    -- occupied by existing entries and, if so, fails.
-    --
-    -- Note: the root path @/@ cannot possibly be occupied by an entry,
-    -- therefore we skip the check for that path.
-    checkForEntriesInEntryPath :: EntryPath -> Sem r ()
-    checkForEntriesInEntryPath entryPath = do
-      let parentDirsExceptRoot = entryPath
-            & Path.entryPathParentDirs
-            & NE.toList
-            -- Ignore paths that cannot possibly point to an entry
-            <&> Path.pathAsEntryPath
-            & rights
-
-      filterM pathIsEntry parentDirsExceptRoot >>= \case
-        (clashed : _) -> throw $ CRParentPathContainsEntry clashed
-        [] -> pure ()
+  checkCreateEntry force entry >>= \case
+    Failure error -> throw $ CRCreateError error
+    Success entry -> do
+      void $ writeSecret entry
+      pure $ CRSuccess entry
 
 setFieldCmd
   :: forall r
@@ -323,22 +291,9 @@ buildCopyOperations oldPath newPath force = do
       Left entry -> copyEntry entry
       Right dir -> copyDir dir
 
-  checkForEntriesInPath newPath
-
-  -- Checks that the paths we're trying to copy entries to aren't already occupied
-  -- by an existing directory.
-  checkCopyOperations operations
-    do \(CopyOperation _ new) -> pathIsDirectory (new ^. E.path)
-    do CPRDestinationIsDirectory . fmap getOperationPaths
-
-  when (not force) do
-    -- Checks that the paths we're trying to copy entries to aren't already occupied
-    -- by an existing entry.
-    checkCopyOperations operations
-      do \(CopyOperation _ new) -> pathIsEntry (new ^. E.path)
-      do CPREntryAlreadyExists . fmap getOperationPaths
-
-  pure operations
+  sequenceA <$> forM operations validateCopyOperation >>= \case
+    Failure createErrors -> throw $ CPRCreateErrors createErrors
+    Success _ -> pure operations
 
   where
     copyEntry :: Entry -> Sem r [CopyOperation]
@@ -368,16 +323,10 @@ buildCopyOperations oldPath newPath force = do
     setModifiedDate nowUtc (CopyOperation old new) =
       CopyOperation old (new & dateModified .~ nowUtc)
 
-    -- | Performs a check on all `CopyOperation`s and throws an error if any of checks fail.
-    checkCopyOperations
-      :: [CopyOperation]
-      -> (CopyOperation -> Sem r Bool)
-      -> (NonEmpty CopyOperation -> CopyResult)
-      -> Sem r ()
-    checkCopyOperations operations pred mkErr = do
-      invalidOperations <- filterM pred operations
-      whenJust (NE.nonEmpty invalidOperations) \invalidOperationsNE ->
-        throw $ mkErr invalidOperationsNE
+    -- | Performs a check on `CopyOperation` and returns @Failure@ if any of checks fail.
+    validateCopyOperation :: CopyOperation -> Sem r (Validation [(EntryPath, CreateError)] Entry)
+    validateCopyOperation (CopyOperation old new) =
+      checkCreateEntry force new <&> first \err -> [(old ^. path, err)]
 
 runCopyOperations :: (Member BackendEffect r) => [CopyOperation] -> Sem r ()
 runCopyOperations operations = do
@@ -396,14 +345,6 @@ copyCmd (CopyOptions dryRun oldPath newPath force) = do
   unless dryRun do
     runCopyOperations operations
   pure $ CPRSuccess $ getOperationPaths <$> operations
-
-    checkForEntriesInPath :: Path -> Sem r ()
-    checkForEntriesInPath path =
-      when (not (null (path ^. pathSegments))) do
-        let pathInits = Path.EntryPath . NE.fromList <$> (tail . inits) (path ^. pathSegments)
-        filterM pathIsEntry pathInits >>= \case
-          [] -> pure ()
-          (entry : _)  -> throw $ CPRDestinationHasEntry entry
 
 deleteCmd
   :: (Member BackendEffect r, Member (Error CofferError) r, Member (Error DeleteResult) r)
@@ -536,3 +477,45 @@ getEntryOrDir path =
                       \ entry or directory name."
                     , "Got: '" <> secret <> "'."
                     ]
+
+-- | This function gets all entries, that are exist in given entry path.
+--
+-- Note: the root path @/@ cannot possibly be occupied by an entry,
+-- therefore we skip the check for that path.
+getEntriesInEntryPath :: forall r. Member BackendEffect r => EntryPath -> Sem r [EntryPath]
+getEntriesInEntryPath entryPath = do
+  let parentDirsExceptRoot = entryPath
+        & Path.entryPathParentDirs
+        & NE.toList
+        -- Ignore paths that cannot possibly point to an entry
+        <&> Path.pathAsEntryPath
+        & rights
+
+  filterM pathIsEntry parentDirsExceptRoot
+
+checkCreateEntry
+  :: forall r
+   . (Member BackendEffect r)
+  => Bool -> Entry -> Sem r (Validation CreateError Entry)
+checkCreateEntry force entry = catchAndReturn act
+  where
+    act :: Sem (Error (Validation CreateError Entry) ': r) (Validation CreateError Entry)
+    act = do
+      let entryPath = entry ^. path
+      whenM (pathIsDirectory entryPath) do
+        throw $ Failure @_ @Entry (CEDestinationIsDirectory entry)
+
+      -- When attempting to create an entry at, e.g., @/a/b/c@, the directories
+      -- @/a@ and @/a/b@ will be implicitly created.
+      --
+      -- Checks whether those paths are already
+      -- occupied by existing entries and, if so, fails.
+      getEntriesInEntryPath entryPath >>= \case
+        (clashed : _) -> throw $ Failure @_ @Entry (CEParentDirectoryIsEntry (entry, clashed))
+        [] -> pure ()
+
+      when (not force) do
+        whenM (pathIsEntry entryPath) do
+          throw $ Failure @_ @Entry (CEEntryAlreadyExists entry)
+
+      pure $ Success entry

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -11,7 +11,6 @@ import Entry (FieldKey, Field, Entry, FieldVisibility, EntryTag)
 import Coffer.Directory (Directory)
 import Coffer.Path (Path, EntryPath)
 import Data.Set (Set)
-import Data.List.NonEmpty ( NonEmpty )
 
 data Command res where
   CmdView :: ViewOptions -> Command ViewResult
@@ -41,11 +40,14 @@ data ViewResult
   | VRDirectoryNoFieldMatch Path FieldKey
   | VREntryNoFieldMatch EntryPath FieldKey
 
+data CreateError
+  = CEParentDirectoryIsEntry (Entry, EntryPath)
+  | CEDestinationIsDirectory Entry
+  | CEEntryAlreadyExists Entry
+
 data CreateResult
   = CRSuccess Entry
-  | CREntryAlreadyExists EntryPath
-  | CRDirectoryAlreadyExists EntryPath
-  | CRParentPathContainsEntry EntryPath
+  | CRCreateError CreateError
 
 data SetFieldResult
   = SFRSuccess Entry
@@ -63,9 +65,7 @@ data CopyResult
   = CPRSuccess [(EntryPath, EntryPath)]
   | CPRPathNotFound Path
   | CPRMissingEntryName
-  | CPRDestinationIsDirectory (NonEmpty (EntryPath, EntryPath))
-  | CPREntryAlreadyExists (NonEmpty (EntryPath, EntryPath))
-  | CPRDestinationHasEntry EntryPath
+  | CPRCreateErrors [(EntryPath, CreateError)]
 
 data DeleteResult
   = DRSuccess [EntryPath]

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -65,6 +65,7 @@ data CopyResult
   | CPRMissingEntryName
   | CPRDestinationIsDirectory (NonEmpty (EntryPath, EntryPath))
   | CPREntryAlreadyExists (NonEmpty (EntryPath, EntryPath))
+  | CPRDestinationHasEntry EntryPath
 
 data DeleteResult
   = DRSuccess [EntryPath]

--- a/tests/golden/create-command/create-command.bats
+++ b/tests/golden/create-command/create-command.bats
@@ -91,8 +91,10 @@ EOF
 
   assert_failure
   assert_output - <<EOF
-[ERROR] An entry already exists at '/a/b/c'.
-Use '--force' or '-f' to overwrite it.
+[ERROR] The entry cannot be created:
+
+An entry already exists at '/a/b/c'.
+Use '--force' or '-f' to overwrite existing entries.
 EOF
 }
 
@@ -165,7 +167,11 @@ EOF
   run coffer create /a/b
 
   assert_failure
-  assert_output "[ERROR] A directory already exists at '/a/b'."
+  assert_output - <<EOF
+[ERROR] The entry cannot be created:
+
+'/a/b' is a directory.
+EOF
 }
 
 @test "creating a directory clashes with existing entry" {
@@ -174,5 +180,9 @@ EOF
   run coffer create /a/b/c
 
   assert_failure
-  assert_output "[ERROR] An entry already exists at '/a/b'."
+  assert_output - <<EOF
+[ERROR] The entry cannot be created:
+
+Attempted to create the directory '/a/b' but an entry exists at that path.
+EOF
 }

--- a/tests/golden/rename-command/config.toml
+++ b/tests/golden/rename-command/config.toml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+main_backend = "vault-local"
+
+[[backend]]
+type = "vault-kv"
+name = "vault-local"
+address = "localhost:8200"
+mount = "secret"
+token = "root"

--- a/tests/golden/rename-command/rename-command.bats
+++ b/tests/golden/rename-command/rename-command.bats
@@ -51,11 +51,14 @@ EOF
 
   assert_failure
   assert_output - <<EOF
-[ERROR] The following entries cannot be renamed because an entry already exists at the destination.
-Use '--force' or '-f' to overwrite existing entries.
+[ERROR] The following entries cannot be renamed:
 
-Cannot rename '/a/b/c' to '/d/c'.
-Cannot rename '/a/b/d' to '/d/d'.
+'/a/b/c' to '/d/c':
+  An entry already exists at '/d/c'.
+  Use '--force' or '-f' to overwrite existing entries.
+'/a/b/d' to '/d/d':
+  An entry already exists at '/d/d'.
+  Use '--force' or '-f' to overwrite existing entries.
 EOF
 }
 
@@ -96,9 +99,10 @@ EOF
 
   assert_failure
   assert_output - <<EOF
-[ERROR] The following entries cannot be renamed because a directory already exists at the destination.
+[ERROR] The following entries cannot be renamed:
 
-Cannot rename '/d' to '/a/b'.
+'/d' to '/a/b':
+  '/a/b' is a directory.
 EOF
 }
 
@@ -152,11 +156,14 @@ EOF
 
   assert_failure
   assert_output - <<EOF
-[ERROR] The following entries cannot be renamed because an entry already exists at the destination.
-Use '--force' or '-f' to overwrite existing entries.
+[ERROR] The following entries cannot be renamed:
 
-Cannot rename '/dir/a' to '/dir/a'.
-Cannot rename '/dir/b' to '/dir/b'.
+'/dir/a' to '/dir/a':
+  An entry already exists at '/dir/a'.
+  Use '--force' or '-f' to overwrite existing entries.
+'/dir/b' to '/dir/b':
+  An entry already exists at '/dir/b'.
+  Use '--force' or '-f' to overwrite existing entries.
 EOF
 
   run coffer rename /dir /dir -f
@@ -198,5 +205,25 @@ EOF
     b/
       c - [2000-01-01 01:01:01]
       d - [2000-01-01 01:01:01]
+EOF
+}
+
+@test "rename multierrors" {
+  coffer create /a/b
+  coffer create /x/b/c
+  coffer create /a/d
+  coffer create /x/d
+
+  run coffer rename /a /x
+
+  assert_failure
+  assert_output - <<EOF
+[ERROR] The following entries cannot be renamed:
+
+'/a/b' to '/x/b':
+  '/x/b' is a directory.
+'/a/d' to '/x/d':
+  An entry already exists at '/x/d'.
+  Use '--force' or '-f' to overwrite existing entries.
 EOF
 }


### PR DESCRIPTION
Problem: there were no checks for entries in destination subpaths in `copy` command.
Solution: created subfunction `checkForEntriesInPath`, which validates that there are no entries in subpaths of a given path.

Fixes #11 