### PR TITLE
[#19] Config path specifying supported

### DIFF
--- a/lib/CLI/Parser.hs
+++ b/lib/CLI/Parser.hs
@@ -47,7 +47,20 @@ parserInfo =
     <> header "TODO: coffer description goes here"
 
 parser :: Parser Options
-parser = Options <$> commandParser
+parser = Options
+  <$> configPathParser
+  <*> commandParser
+  where
+    configPathParser :: Parser FilePath
+    configPathParser =
+      option str $ mconcat
+        [ long "config"
+        , short 'c'
+        , metavar "CONFIG"
+        , value "./config.toml"
+        , showDefault
+        , help "Specify config file path"
+        ]
 
 commandParser :: Parser SomeCommand
 commandParser =

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -12,7 +12,10 @@ import Coffer.Directory (Directory)
 import Coffer.Path (Path, EntryPath, QualifiedPath)
 import Data.Set (Set)
 
-newtype Options = Options { oSomeCommand :: SomeCommand }
+data Options = Options
+  { oConfigPath :: FilePath
+  , oSomeCommand :: SomeCommand
+  }
   deriving stock Show
 
 data Command res where


### PR DESCRIPTION
Problem: you cannot use multiple configs for `coffer`.
Solution: added optional argument `[-c|--config]` to specify your config path.

Fixed: #19