### PR TITLE
[#29] Add CLI parser

### DIFF
--- a/coffer.cabal
+++ b/coffer.cabal
@@ -102,7 +102,6 @@ library
     , tomland
     , unordered-containers
     , validation-selective
-    , vector
   default-language: Haskell2010
 
 executable coffer

--- a/coffer.cabal
+++ b/coffer.cabal
@@ -22,6 +22,8 @@ library
       Backend.Vault.Kv
       Backend.Vault.Kv.Internal
       Backends
+      CLI.Parser
+      CLI.Types
       Coffer.Path
       Config
       Entry
@@ -93,12 +95,15 @@ library
     , http-types
     , lens
     , lens-aeson
+    , megaparsec
+    , optparse-applicative
     , polysemy
     , servant
     , servant-client
     , servant-client-core
     , text
     , time
+    , time-compat
     , tomland
     , unordered-containers
     , validation-selective

--- a/coffer.cabal
+++ b/coffer.cabal
@@ -22,6 +22,7 @@ library
       Backend.Vault.Kv
       Backend.Vault.Kv.Internal
       Backends
+      Coffer.Path
       Config
       Entry
       Entry.Json
@@ -84,6 +85,8 @@ library
       aeson
     , base >=4.14.3.0 && <5
     , containers
+    , extra
+    , fmt
     , hashable
     , http-client
     , http-client-tls

--- a/lib/Backend.hs
+++ b/lib/Backend.hs
@@ -17,6 +17,7 @@ import Error                         (CofferError)
 import Polysemy.Error                (Error)
 
 import Polysemy
+import Coffer.Path (EntryPath, Path)
 
 -- @TODO - rename Secret to Entry?
 data BackendEffect m a where
@@ -26,11 +27,11 @@ data BackendEffect m a where
   WriteSecret  :: E.Entry -> BackendEffect m ()
   -- | Returns path segments: if the segment is suffixed by @/@ then that indicates a directory;
   --   otherwise it's an entry
-  ReadSecret   :: [T.Text] -> BackendEffect m (Maybe E.Entry)
-  ListSecrets  :: [T.Text] -> BackendEffect m (Maybe [T.Text])
+  ReadSecret   :: EntryPath -> BackendEffect m (Maybe E.Entry)
+  ListSecrets  :: Path -> BackendEffect m (Maybe [T.Text])
   -- | Once all entries are deleted from a directory, then the directory disappears
   --   (i.e. @ListSecrets@ will no longer list that directory)
-  DeleteSecret :: [T.Text] -> BackendEffect m ()
+  DeleteSecret :: EntryPath -> BackendEffect m ()
 makeSem ''BackendEffect
 
 class Show a => Backend a where

--- a/lib/CLI/Parser.hs
+++ b/lib/CLI/Parser.hs
@@ -1,0 +1,550 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+{-# LANGUAGE OverloadedLists #-}
+
+module CLI.Parser
+  ( parserInfo
+  ) where
+
+import Options.Applicative
+import qualified Options.Applicative.Help.Pretty as Pretty
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Map (Map)
+import qualified Data.Map as M
+import Data.Functor ((<&>), ($>))
+import qualified Data.List as List
+import Data.Function ((&))
+import Control.Arrow ((>>>))
+import qualified Text.Megaparsec as P
+import qualified Text.Megaparsec.Char as P
+import qualified Text.Megaparsec.Char.Lexer as P
+import Data.Void ( Void )
+import Data.Foldable (asum)
+import Data.Time.Compat (LocalTime (..), makeTimeOfDayValid, localTimeToUTC, utc)
+import Data.Time.Calendar.Compat ( fromGregorianValid )
+import Data.Time.Calendar.Month.Compat (fromYearMonthValid)
+import Control.Monad (guard, void)
+import qualified Data.Char as Char
+import Data.Fixed (Pico)
+import Data.Bifunctor (first)
+import qualified Data.Set as Set
+
+import CLI.Types
+import Entry (FieldKey, EntryTag, newEntryTag, newFieldKey, FieldVisibility (Public, Private))
+import Coffer.Path (Path, mkPath, EntryPath, mkEntryPath)
+
+{-# ANN module ("HLint: ignore Use <$>" :: Text) #-}
+
+parserInfo :: ParserInfo Command
+parserInfo =
+  info (parser <**> helper) $
+    fullDesc
+    <> progDesc "TODO: coffer description goes here"
+    <> header "TODO: coffer description goes here"
+
+parser :: Parser Command
+parser =
+  subparser $ mconcat
+    [ mkCommand "view" CmdView viewOptions
+        "View entries under the specified path, optionally returning only the specified field for each entry"
+    , mkCommand "create" CmdCreate createOptions
+        "Create a new entry at the specified path"
+    , mkCommand "set-field" CmdSetField setFieldOptions
+        "Set a field on the entry at the specified path"
+    , mkCommand "delete-field" CmdDeleteField deleteFieldOptions
+        "Delete a field from the entry at the specified path"
+    , mkCommand "find" CmdFind findOptions
+        "Find and list entries, optionally filtering"
+    , mkCommand "rename" CmdRename renameOptions
+        "Rename an entry or directory"
+    , mkCommand "copy" CmdCopy copyOptions
+        "Copy an entry or directory"
+    , mkCommand "delete" CmdDelete deleteOptions
+        "Delete an entry or directory"
+    , mkCommand "tag" CmdTag tagOptions
+        "Add or remove tags from an entry"
+    ]
+  where
+    mkCommand :: String -> (opts -> a) -> Parser opts -> String -> Mod CommandFields a
+    mkCommand cmdName constructor optsParser cmdHelp =
+      command cmdName $
+        info (helper <*> (constructor <$> optsParser)) $
+        progDesc cmdHelp
+
+----------------------------------------------------------------------------
+-- Options
+----------------------------------------------------------------------------
+
+viewOptions :: Parser ViewOptions
+viewOptions = do
+  ViewOptions
+    <$> argument readPath ( mconcat
+          [ metavar "PATH"
+          , help "The path to either a directory of entries, or a single entry"
+          ])
+    <*> optional
+          ( argument readFieldKey $ mconcat
+              [ metavar "FIELDNAME"
+              , help "The optional field name to fetch the contents of"
+              ]
+          )
+
+createOptions :: Parser CreateOptions
+createOptions =
+  CreateOptions
+    <$> argument readEntryPath ( mconcat
+          [ metavar "ENTRYPATH"
+          , help "The path to insert the new entry into, this must not already be a directory or an entry unless `-f` is specified"
+          ])
+    <*> switch ( mconcat
+          [ long "edit"
+          , short 'e'
+          , help $ unlines
+              [ "Open an editor to configure the fields and tags for this entry."
+              , "By default, `vi` will be used."
+              , "This can be set using the `$EDITOR` environment variable."
+              ]
+          ])
+    <*> switch ( mconcat
+          [ long "force"
+          , short 'f'
+          , help "If a directory or entry already exists under the specified path, delete it and insert this entry instead"
+          ])
+    <*> (Set.fromList <$> many ( option readEntryTag $ mconcat
+          [ long "tag"
+          , metavar "TAG"
+          , help "Tag to add to this new entry, this may be specified multiple times"
+          ])
+        )
+    <*> many ( option readFieldInfo $ mconcat
+          [ long "field"
+          , metavar "NAME=CONTENT"
+          , help "A field to insert into the new entry, with the format 'fieldname=fieldcontents', this may be specified multiple times"
+          ])
+    <*> many ( option readFieldInfo $ mconcat
+          [ long "privatefield"
+          , metavar "NAME=CONTENT"
+          , help $ unlines
+              [ "Same as `--field`, but the field will be marked as private."
+              , "Private fields can only be viewed with 'coffer view',"
+              , "and will be hidden when using other commands."
+              ]
+          ])
+
+setFieldOptions :: Parser SetFieldOptions
+setFieldOptions =
+  SetFieldOptions
+    <$> argument readEntryPath ( mconcat
+          [ metavar "ENTRYPATH"
+          , help "The path to set the field value on, this must already exist as an entry"
+          ])
+    <*> argument readFieldKey ( mconcat
+          [ metavar "FIELDNAME"
+          , help "The name of the field to set"
+          ])
+    <*> optional (argument str $ mconcat
+          [ metavar "FIELDCONTENTS"
+          , help "The contents to insert into the field. Required when creating a new field, optional otherwise"
+          ])
+    <*> optional (option readFieldVisibility $ mconcat
+          [ long "visibility"
+          , short 'V'
+          , metavar "VISIBILITY"
+          , help $ unlines
+              [ "Whether to mark this field as 'public' or 'private'"
+              , "New fields are public by default when this option is omitted."
+              , "Private fields can only be viewed with 'coffer view',"
+              , "and will be hidden when using other commands."
+              ]
+          ])
+
+deleteFieldOptions :: Parser DeleteFieldOptions
+deleteFieldOptions =
+  DeleteFieldOptions
+    <$> argument readEntryPath ( mconcat
+          [ metavar "ENTRYPATH"
+          , help "The path to the entry with the field to delete"
+          ])
+    <*> argument readFieldKey ( mconcat
+          [ metavar "FIELDNAME"
+          , help "The name of the field to delete"
+          ])
+
+findOptions :: Parser FindOptions
+findOptions =
+  FindOptions
+    <$> optional (argument readPath $ mconcat
+          [ metavar "PATH"
+          , help "If specified, only show entries within this path (use `/` to find everything)"
+          ])
+    <*> optional (argument str $ mconcat
+          [ metavar "TEXT"
+          , help "The text to search for in the paths and tags of entries"
+          ])
+    <*> optional (option readSort $ mconcat
+          [ metavar "SORT"
+          , long "sort"
+          , helpDoc $ Just $ Pretty.vsep
+            [ "Sort the entries inside each directory."
+            , expectedSortFormat
+            ]
+          ])
+    <*> many (option readFilter $ mconcat
+          [ metavar "FILTER"
+          , long "filter"
+          , helpDoc $ Just $ Pretty.vsep
+            [ "Filter entries."
+            , expectedFilterFormat
+            ]
+          ])
+    <*> many (option readFilterField $ mconcat
+          [ metavar "FILTERFIELD"
+          , long "filter-field"
+          , helpDoc $ Just $ Pretty.vsep
+            [ "Filter entries based on a field."
+            , expectedFilterFieldFormat
+            ]
+          ])
+
+renameOptions :: Parser RenameOptions
+renameOptions =
+  RenameOptions
+    <$> argument readPath ( mconcat
+          [ metavar "OLDPATH"
+          , help "The path to move the old directory or entry from"
+          ])
+    <*> argument readPath ( mconcat
+          [ metavar "NEWPATH"
+          , help "The path to move the directory or entry to"
+          ])
+    <*> switch ( mconcat
+          [ long "force"
+          , short 'f'
+          , help "If a directory or entry already exists under the specified path, delete it and insert this entry instead"
+          ])
+
+copyOptions :: Parser CopyOptions
+copyOptions =
+  CopyOptions
+    <$> argument readPath ( mconcat
+          [ metavar "OLDPATH"
+          , help "The path to copy the old directory or entry from"
+          ])
+    <*> argument readPath ( mconcat
+          [ metavar "NEWPATH"
+          , help "The path to copy the directory or entry to"
+          ])
+    <*> switch ( mconcat
+          [ long "force"
+          , short 'f'
+          , help "If a directory or entry already exists under the specified path, delete it and insert this entry instead"
+          ])
+
+deleteOptions :: Parser DeleteOptions
+deleteOptions =
+  DeleteOptions
+    <$> argument readPath ( mconcat
+          [ metavar "PATH"
+          , help "The path to the entry or directory to delete"
+          ])
+    <*> switch ( mconcat
+          [ long "recursive"
+          , short 'r'
+          , help "If the specified path is a directory, remove it and its contents"
+          ])
+
+tagOptions :: Parser TagOptions
+tagOptions =
+  TagOptions
+    <$> argument readEntryPath ( mconcat
+          [ metavar "ENTRYPATH"
+          , help "The path to the entry to add or delete a tag from"
+          ])
+    <*> argument readEntryTag ( mconcat
+          [ metavar "TAGNAME"
+          , help "The name of the tag to add or delete"
+          ])
+    <*> switch ( mconcat
+          [ long "delete"
+          , short 'd'
+          , help "Remove this tag instead of setting it"
+          ])
+
+----------------------------------------------------------------------------
+-- Common
+----------------------------------------------------------------------------
+
+readPath :: ReadM Path
+readPath = do
+  eitherReader \input ->
+    mkPath (T.pack input) & first \err -> unlines
+      [ "Invalid path: '" <> input <> "'."
+      , T.unpack err
+      ]
+
+readEntryPath :: ReadM EntryPath
+readEntryPath = do
+  eitherReader \input ->
+    mkEntryPath (T.pack input) & first \err -> unlines
+      [ "Invalid entry path: '" <> input <> "'."
+      , T.unpack err
+      ]
+
+readEntryTag :: ReadM EntryTag
+readEntryTag = do
+  eitherReader \input ->
+    newEntryTag (T.pack input) & first \err -> unlines
+      [ "Invalid tag: '" <> input <> "'."
+      , T.unpack err
+      ]
+
+readFieldVisibility :: ReadM FieldVisibility
+readFieldVisibility =
+  eitherReader $ readSum "visibility"
+    [ ("public", Public)
+    , ("private", Private)
+    ]
+
+readFieldKey :: ReadM FieldKey
+readFieldKey = str >>= toReader . readFieldKey'
+
+readFieldKey' :: Text -> Either String FieldKey
+readFieldKey' input = do
+  case newFieldKey input of
+    Right tag -> pure tag
+    Left err -> Left $ unlines
+      [ "Invalid field name: '" <> T.unpack input <> "'."
+      , T.unpack err
+      ]
+
+readFieldInfo :: ReadM FieldInfo
+readFieldInfo = do
+  eitherReader \input ->
+    P.parse (parseFieldInfo <* P.eof) "" (T.pack input) & first \err ->unlines
+      [ "Invalid field format: '" <> input <> "'."
+      , "Expected format: 'fieldname=fieldcontents'."
+      , ""
+      , "Parser error:"
+      , P.errorBundlePretty err
+      ]
+
+readSort :: ReadM (Sort, Direction)
+readSort = do
+  eitherReader \input ->
+    case T.splitOn ":" (T.pack input) of
+      [means, direction] -> do
+        direction' <- readDirection direction
+        case means of
+          "name" -> pure (SortByEntryName, direction')
+          "date" -> pure (SortByEntryDate, direction')
+          _ -> Left $ unlines
+            [ "Invalid sort: '" <> T.unpack means <> "'."
+            , "Choose one of: 'name', 'date'."
+            , ""
+            , show expectedSortFormat
+            ]
+      [fieldName, means, direction] -> do
+        fieldName' <- readFieldKey' fieldName
+        direction' <- readDirection direction
+        case means of
+          "value" -> pure (SortByFieldValue fieldName', direction')
+          "date" -> pure (SortByFieldDate fieldName', direction')
+          _ -> Left $ unlines
+            [ "Invalid sort: '" <> T.unpack means <> "'."
+            , "Choose one of: 'value', 'date'."
+            , ""
+            , show expectedSortFormat
+            ]
+      _ -> Left $ unlines
+        [ "Invalid sort format: '" <> input <> "'."
+        , show expectedSortFormat
+        ]
+
+expectedSortFormat :: Pretty.Doc
+expectedSortFormat = Pretty.vsep
+  [ "Expected format is:"
+  , " * to sort by entry name: 'name:<direction>',"
+  , " * to sort by the entry's last modified date: 'date:<direction>',"
+  , " * to sort by a field's value: '<fieldname>:value:<direction>',"
+  , " * to sort by a field's last modified date: '<fieldname>:date:<direction>'."
+  , "Direction can be 'asc' or 'desc'."
+  , "Examples: 'name:desc', 'password:date:asc'."
+  ]
+
+readDirection :: Text -> Either String Direction
+readDirection =
+  T.unpack >>> readSum "direction"
+    [ ("asc", Asc)
+    , ("desc", Desc)
+    ]
+
+readFilter :: ReadM Filter
+readFilter = do
+  eitherReader \input ->
+    P.parse (parseFilter <* P.eof) "" (T.pack input) & first \err -> unlines
+      [ "Invalid filter format: '" <> input <> "'."
+      , show expectedFilterFormat
+      , ""
+      , "Parser error:"
+      , P.errorBundlePretty err
+      ]
+
+expectedFilterFormat :: Pretty.Doc
+expectedFilterFormat = Pretty.vsep
+  [ "Expected format is: 'name~<substring>' or `date<op><date>`."
+  , "<op> can be '<=', '>=', '<', '>', or '='."
+  , "<date> can be 'YYYY', 'YYYY-MM', 'YYYY-MM-DD', or 'YYYY-MM-DD HH:MM:SS'."
+  , "Examples: 'name~vault', 'date<2020-02'."
+  ]
+
+readFilterField :: ReadM (FieldKey, FilterField)
+readFilterField = do
+  eitherReader \input ->
+    P.parse (parseFilterField <* P.eof) "" (T.pack input) & first \err -> unlines
+      [ "Invalid filter-field format: '" <> input <> "'."
+      , show expectedFilterFieldFormat
+      , ""
+      , "Parser error:"
+      , P.errorBundlePretty err
+      ]
+
+expectedFilterFieldFormat :: Pretty.Doc
+expectedFilterFieldFormat = Pretty.vsep
+  [ "Expected format is: '<fieldname>:value~<substring>' or `<fieldname>:date<op><date>`."
+  , "<op> can be '<=', '>=', '<', '>', or '='."
+  , "<date> can be 'YYYY', 'YYYY-MM', 'YYYY-MM-DD', or 'YYYY-MM-DD HH:MM:SS'."
+  , "Examples: 'url:value~google.com', 'pw:date<2020-02'."
+  ]
+
+----------------------------------------------------------------------------
+-- Megaparsec
+----------------------------------------------------------------------------
+
+type MParser = P.Parsec Void Text
+
+-- | Parses any of these formats:
+--
+-- * @YYYY@
+-- * @YYYY-MM@
+-- * @YYYY-MM-DD@
+-- * @YYYY-MM-DD HH:MM:SS@
+parseFilterDate :: MParser FilterDate
+parseFilterDate = do
+  y <- P.decimal
+  optional (P.char '-') >>= \case
+    Nothing -> pure $ FDYear y
+    Just _ -> do
+      m <- twoDigits
+      optional (P.char '-') >>= \case
+        Nothing ->
+          case fromYearMonthValid y m of
+            Nothing -> fail "invalid year/month"
+            Just month -> pure $ FDMonth month
+        Just _ -> do
+          d <- twoDigits
+          case fromGregorianValid y m d of
+            Nothing -> fail "invalid year/month/day"
+            Just day ->
+              optional (P.char ' ') >>= \case
+                Nothing -> pure $ FDDay day
+                Just _ -> do
+                  hh <- twoDigits <* P.char ':'
+                  mm <- twoDigits <* P.char ':'
+                  ss <- twoDigits
+                  case makeTimeOfDayValid hh mm (fromIntegral @Int @Pico ss) of
+                    Nothing -> fail "invalid hour/minute/seconds"
+                    Just timeOfDay -> pure $ FDTime (localTimeToUTC utc $ LocalTime day timeOfDay)
+  where
+    -- | Parse a two-digit integer (e.g. day of month, hour).
+    twoDigits :: MParser Int
+    twoDigits = do
+      a <- P.digitChar
+      b <- P.digitChar
+      pure $ Char.digitToInt a * 10 + Char.digitToInt b
+
+parseFilterOp :: MParser FilterOp
+parseFilterOp =
+  asum @[]
+    [ P.string ">=" $> OpGTE
+    , P.string "<=" $> OpLTE
+    , P.char '>' $> OpGT
+    , P.char '<' $> OpLT
+    , P.char '=' $> OpEQ
+    ]
+
+parseFilter :: MParser Filter
+parseFilter =
+  parseFilterByName <|> parseFilterByDate
+  where
+    parseFilterByName = do
+      void $ P.string "name" >> P.char '~'
+      rest <- P.takeRest
+      guard (not $ T.null rest)
+      pure $ FilterByName rest
+    parseFilterByDate = do
+      void $ P.string "date"
+      op <- parseFilterOp
+      localTime <- parseFilterDate
+      pure $ FilterByDate op localTime
+
+parseFilterField :: MParser (FieldKey, FilterField)
+parseFilterField = do
+  fieldName <- parseFieldNameWhile (/= ':')
+  void $ P.char ':'
+  filterField <- parseFilterFieldByValue <|> parseFilterFieldByDate
+
+  pure (fieldName, filterField)
+  where
+    parseFilterFieldByValue = do
+      void $ P.string "value" >> P.char '~'
+      rest <- P.takeRest
+      guard (not $ T.null rest)
+      pure $ FilterFieldByValue rest
+    parseFilterFieldByDate = do
+      op <- P.string "date" >> parseFilterOp
+      localTime <- parseFilterDate
+      pure $ FilterFieldByDate op localTime
+
+parseFieldInfo :: MParser FieldInfo
+parseFieldInfo = do
+  fieldName <- parseFieldNameWhile \c -> c /= '=' && not (Char.isSpace c)
+  P.hspace >> P.char '=' >> P.hspace
+  fieldContents <- parseFieldContentsEof
+  pure $ FieldInfo fieldName fieldContents
+
+parseFieldNameWhile :: (Char -> Bool) -> MParser FieldKey
+parseFieldNameWhile whileCond = do
+  fieldName <- P.takeWhile1P (Just "fieldname") whileCond
+  either fail pure $ readFieldKey' fieldName
+
+-- | Parse the rest of the input as a field content.
+parseFieldContentsEof :: MParser Text
+parseFieldContentsEof = T.pack <$> P.manyTill P.anySingle P.eof
+
+----------------------------------------------------------------------------
+-- Utils
+----------------------------------------------------------------------------
+
+toReader :: Either String a -> ReadM a
+toReader = either readerError pure
+
+readSum ::  String -> Map String a -> String -> Either String a
+readSum sumDescription constructors input =
+  case M.lookup input constructors of
+    Just cons -> Right cons
+    Nothing ->
+      Left $ unlines
+        [ "Invalid " <> sumDescription <> ": '" <> input <> "'."
+        , "Choose one of: " <> constructorNames <> "."
+        ]
+  where
+    constructorNames :: String
+    constructorNames =
+      constructors
+        & M.keys
+        <&> (\name -> "'" <> name <> "'")
+        & List.intersperse ", "
+        & mconcat

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -1,0 +1,134 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module CLI.Types where
+
+import Data.Text (Text)
+import Data.Time.Compat (Day, UTCTime , Year)
+import Data.Time.Calendar.Month.Compat (Month)
+import Entry (FieldKey, FieldVisibility, EntryTag)
+import Coffer.Path (Path, EntryPath)
+import Data.Set (Set)
+
+data Command
+  = CmdView ViewOptions
+  | CmdCreate CreateOptions
+  | CmdSetField SetFieldOptions
+  | CmdDeleteField DeleteFieldOptions
+  | CmdFind FindOptions
+  | CmdRename RenameOptions
+  | CmdCopy CopyOptions
+  | CmdDelete DeleteOptions
+  | CmdTag TagOptions
+  deriving stock Show
+
+----------------------------------------------------------------------------
+-- Options
+----------------------------------------------------------------------------
+
+data ViewOptions = ViewOptions
+  { voPath :: Path
+  , voFieldName :: Maybe FieldKey
+  }
+  deriving stock Show
+
+data CreateOptions = CreateOptions
+  { coPath :: EntryPath
+  , coEdit :: Bool
+  , coForce :: Bool
+  , coTags :: Set EntryTag
+  , coFields :: [FieldInfo]
+  , coPrivateFields :: [FieldInfo]
+  }
+  deriving stock Show
+
+data SetFieldOptions = SetFieldOptions
+  { sfoPath :: EntryPath
+  , sfoFieldName :: FieldKey
+  , sfoFieldContents :: Maybe Text
+  , sfoVisibility :: Maybe FieldVisibility
+  }
+  deriving stock Show
+
+data DeleteFieldOptions = DeleteFieldOptions
+  { dfoPath :: EntryPath
+  , dfoFieldName :: FieldKey
+  }
+  deriving stock Show
+
+data FindOptions = FindOptions
+  { foPath :: Maybe Path
+  , foText :: Maybe Text
+  , foSort :: Maybe (Sort, Direction)
+  , foFilters :: [Filter]
+  , foFilterFields :: [(FieldKey, FilterField)]
+  }
+  deriving stock Show
+
+data RenameOptions = RenameOptions
+  { roOldPath :: Path
+  , roNewPath :: Path
+  , roForce :: Bool
+  }
+  deriving stock Show
+
+data CopyOptions = CopyOptions
+  { cpoOldPath :: Path
+  , cpoNewPath :: Path
+  , cpoForce :: Bool
+  }
+  deriving stock Show
+
+data DeleteOptions = DeleteOptions
+  { doPath :: Path
+  , doRecursive :: Bool
+  }
+  deriving stock Show
+
+data TagOptions = TagOptions
+  { toPath :: EntryPath
+  , toTagName :: EntryTag
+  , toDelete :: Bool
+  }
+  deriving stock Show
+
+----------------------------------------------------------------------------
+-- Option arguments
+----------------------------------------------------------------------------
+
+data FieldInfo = FieldInfo
+  { fiName :: FieldKey
+  , fiContents :: Text
+  }
+  deriving stock Show
+
+data Direction = Asc | Desc
+  deriving stock Show
+
+data Sort
+  = SortByEntryName
+  | SortByEntryDate
+  | SortByFieldValue FieldKey
+  | SortByFieldDate FieldKey
+  deriving stock Show
+
+data FilterOp = OpGT | OpGTE | OpLT | OpLTE | OpEQ
+  deriving stock Show
+
+data FilterDate
+  = FDYear Year
+  | FDMonth Month
+  | FDDay Day
+  | FDTime UTCTime
+  deriving stock Show
+
+data Filter
+  = FilterByDate FilterOp FilterDate
+  | FilterByName Text
+  deriving stock Show
+
+data FilterField
+  = FilterFieldByDate FilterOp FilterDate
+  | FilterFieldByValue Text
+  deriving stock Show

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -1,0 +1,195 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module Coffer.Path
+  ( PathSegment
+  , unPathSegment
+  , mkPathSegment
+  , pathSegmentAllowedCharacters
+  , Path(..)
+  , isoPath
+  , pathSegments
+  , mkPath
+  , EntryPath(..)
+  , isoEntryPath
+  , mkEntryPath
+  , entryPathName
+  , entryPathParentDir
+  , entryPathSegments
+  , appendEntryName
+  , pathAsEntryPath
+  , entryPathAsPath
+  , replacePathPrefix
+  ) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import Fmt (Buildable, build, pretty)
+import Data.Maybe (fromMaybe)
+import Data.Hashable (Hashable)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Control.Lens
+import qualified Data.List.NonEmpty as NE
+import Control.Monad ((>=>))
+import qualified Data.List as List
+
+-- $setup
+-- >>> import Fmt (pretty, build)
+-- >>> import Control.Lens
+-- >>> isRight (Right a) = a
+-- >>> unsafeMkPath = isRight . mkPath
+-- >>> unsafeMkEntryPath = isRight . mkEntryPath
+-- >>> unsafeMkPathSegment = isRight . mkPathSegment
+
+newtype PathSegment = UnsafeMkPathSegment { unPathSegment :: Text }
+  deriving stock (Show, Eq)
+  deriving newtype (Buildable, Hashable)
+
+mkPathSegment :: Text -> Either Text PathSegment
+mkPathSegment segment
+  | T.null segment =
+      Left "Path segments must contain at least 1 character"
+  | T.any (`notElem` pathSegmentAllowedCharacters) segment =
+      Left $ "Path segments can only contain the following characters: '" <> T.pack pathSegmentAllowedCharacters <> "'"
+  | otherwise = Right $ UnsafeMkPathSegment segment
+
+pathSegmentAllowedCharacters :: [Char]
+pathSegmentAllowedCharacters = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ "-_"
+
+-- | Path to a directory or an entry.
+newtype Path = Path { unPath :: [PathSegment] }
+  deriving stock (Show, Eq)
+  deriving newtype (Semigroup, Monoid)
+
+makeLensesFor [("unPath", "isoPath")] ''Path
+
+-- |
+-- >>> pretty @Path @String <$> mkPath "a/b/c"
+-- Right "/a/b/c"
+instance Buildable Path where
+  build (Path segments) = "/" <> build (T.intercalate "/" $ pretty <$> segments)
+
+-- | Retrieve a list of a path's segments.
+--
+-- >>> pathSegments $ unsafeMkPath "/a/b/c"
+-- ["a","b","c"]
+pathSegments :: Path -> [Text]
+pathSegments p = p ^.. isoPath . each . to unPathSegment
+
+-- | Parses a path to a directory or entry.
+--
+-- Leading and trailing slashes are optional.
+--
+-- >>> pretty <$> mkPath "/"
+-- Right "/"
+-- >>> pretty <$> mkPath ""
+-- Right "/"
+-- >>> pretty <$> mkPath "/a/"
+-- Right "/a"
+-- >>> pretty <$> mkPath "a"
+-- Right "/a"
+-- >>> pretty <$> mkPath "/a/b/c"
+-- Right "/a/b/c"
+mkPath :: Text -> Either Text Path
+mkPath path = do
+  let segments = path
+        & stripPrefix
+        & stripSuffix
+        & T.splitOn "/"
+
+  if segments == [""]
+    then Right $ Path []
+    else Path <$> traverse mkPathSegment segments
+
+  where
+    stripPrefix s = fromMaybe s $ T.stripPrefix "/" s
+    stripSuffix s = fromMaybe s $ T.stripSuffix "/" s
+
+-- | An entry's full path (directory + entry's name).
+newtype EntryPath = EntryPath { unEntryPath :: NonEmpty PathSegment }
+  deriving stock (Show, Eq)
+
+makeLensesFor [("unEntryPath", "isoEntryPath")] ''EntryPath
+
+-- |
+-- >>> pretty @EntryPath @String <$> mkEntryPath "a/b/c"
+-- Right "/a/b/c"
+instance Buildable EntryPath where
+  build (EntryPath segments) = build $ Path $ NE.toList segments
+
+
+mkEntryPath :: Text -> Either Text EntryPath
+mkEntryPath = mkPath >=> pathAsEntryPath
+
+-- | Focus the name of the entry.
+--
+-- >>> unsafeMkEntryPath "/a/b/c" & entryPathName
+-- "c"
+entryPathName :: EntryPath -> Text
+entryPathName = view $ isoEntryPath . last1 . to unPathSegment
+
+-- | Focus the path to the directory this entry is in.
+--
+-- >>> unsafeMkEntryPath "/parent/dir/c" ^. entryPathParentDir . to build
+-- "/parent/dir"
+--
+-- >>> build $ unsafeMkEntryPath "/old/parent1/c" & entryPathParentDir .~ unsafeMkPath "/new/parent2"
+-- "/new/parent2/c"
+entryPathParentDir :: Lens' EntryPath Path
+entryPathParentDir = isoEntryPath . initNE . from isoPath
+
+-- | Retrieve a list of a path's segments.
+--
+-- >>> entryPathSegments $ unsafeMkEntryPath "/a/b/c"
+-- ["a","b","c"]
+entryPathSegments :: EntryPath -> [Text]
+entryPathSegments p = p ^.. isoEntryPath . each . to unPathSegment
+
+-- | Build an `EntryPath` by append the entry's name to its location path.
+--
+-- >>> build $ appendEntryName (unsafeMkPath "/my/directory") (unsafeMkPathSegment "entryname")
+-- "/my/directory/entryname"
+appendEntryName :: Path -> PathSegment -> EntryPath
+appendEntryName (Path segments) entryName = EntryPath $ appendNE segments entryName
+
+-- | Attempts to cast a `Path` to an `EntryPath`.
+pathAsEntryPath :: Path -> Either Text EntryPath
+pathAsEntryPath (Path segments) =
+  case NE.nonEmpty segments of
+    Just ep -> Right $ EntryPath ep
+    Nothing -> Left "Entry paths must not be empty."
+
+-- | Casts an `EntryPath` to a `Path`.
+entryPathAsPath :: EntryPath -> Path
+entryPathAsPath (EntryPath segments) = Path $ NE.toList segments
+
+-- | Replaces the prefix of a given path.
+--
+-- >>> oldPrefix = unsafeMkPath "sre/github"
+-- >>> newPrefix = unsafeMkPath "sre/gitlab"
+-- >>> build $ replacePathPrefix oldPrefix newPrefix (unsafeMkPath "/sre/github/serokell-bot")
+-- "/sre/gitlab/serokell-bot"
+--
+-- Returns `Nothing` when the given path does _not_ have the expected prefix.
+replacePathPrefix :: Path -> Path -> Path -> Maybe Path
+replacePathPrefix (Path oldPrefix) (Path newPrefix) (Path fullpath) =
+  fullpath
+    & List.stripPrefix oldPrefix
+    <&> mappend newPrefix
+    <&> Path
+
+----------------------------------------------------------------------------
+-- Helpers
+----------------------------------------------------------------------------
+
+-- | Append an item to the end of a list.
+appendNE :: [a] -> a -> NonEmpty a
+appendNE xs last =
+  case xs of
+    [] -> last :| []
+    (x : xs) -> x :| xs <> [last]
+
+-- | Focus every element except the last.
+initNE :: Lens' (NonEmpty a) [a]
+initNE = lens NE.init \ne newInit -> appendNE newInit (NE.last ne)

--- a/lib/Entry.hs
+++ b/lib/Entry.hs
@@ -21,6 +21,7 @@ import Control.Lens
 import qualified Data.Aeson.Types as A
 import Data.Hashable (Hashable)
 import Data.Time (UTCTime)
+import Coffer.Path (EntryPath)
 
 newtype FieldKey = UnsafeFieldKey T.Text
   deriving stock (Show, Eq)
@@ -72,7 +73,7 @@ newField time value =
 
 data Entry =
   Entry
-  { ePath :: [T.Text]
+  { ePath :: EntryPath
   , eDateModified :: UTCTime
   , eMasterField :: Maybe FieldKey
   , eFields :: HS.HashMap FieldKey Field
@@ -81,7 +82,7 @@ data Entry =
   deriving stock (Show, Eq)
 makeLensesWith abbreviatedFields ''Entry
 
-newEntry :: [T.Text] -> UTCTime -> Entry
+newEntry :: EntryPath -> UTCTime -> Entry
 newEntry path time =
   Entry
   { ePath = path

--- a/lib/Entry.hs
+++ b/lib/Entry.hs
@@ -32,12 +32,13 @@ newtype FieldKey = UnsafeFieldKey T.Text
 keyCharSet :: [Char]
 keyCharSet = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ "-_;"
 
-newFieldKey :: T.Text -> Maybe FieldKey
-newFieldKey t =
-  if T.all (`elem` keyCharSet) t && not (T.null t) then
-    Just $ UnsafeFieldKey t
-  else
-    Nothing
+newFieldKey :: Text -> Either Text FieldKey
+newFieldKey t
+  | T.null t =
+      Left "Tags must contain at least 1 character"
+  | T.any (`notElem` keyCharSet) t =
+      Left $ "Tags can only contain the following characters: '" <> T.pack keyCharSet <> "'"
+  | otherwise = Right $ UnsafeFieldKey t
 
 getFieldKey :: FieldKey -> T.Text
 getFieldKey (UnsafeFieldKey t) = t
@@ -46,12 +47,13 @@ newtype EntryTag = UnsafeEntryTag T.Text
   deriving stock (Show, Eq, Ord)
   deriving newtype (A.ToJSON, A.FromJSON)
 
-newEntryTag :: T.Text -> Maybe EntryTag
-newEntryTag t =
-  if T.all (`elem` keyCharSet) t && not (T.null t) then
-    Just $ UnsafeEntryTag t
-  else
-    Nothing
+newEntryTag :: Text -> Either Text EntryTag
+newEntryTag tag
+  | T.null tag =
+      Left "Tags must contain at least 1 character"
+  | T.any (`notElem` keyCharSet) tag =
+      Left $ "Tags can only contain the following characters: '" <> T.pack keyCharSet <> "'"
+  | otherwise = Right $ UnsafeEntryTag tag
 
 getEntryTag :: EntryTag -> T.Text
 getEntryTag (UnsafeEntryTag t) = t

--- a/lib/Entry.hs
+++ b/lib/Entry.hs
@@ -4,6 +4,7 @@
 
 module Entry
   ( dateModified
+  , keyCharSet
   , Entry, EntryConvertible (..), newEntry
   , path, masterField, fields
   , Field (..), FieldKey,  newField, getFieldKey
@@ -12,7 +13,6 @@ module Entry
   , FieldVisibility(..)
   )
 where
-
 
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/lib/Entry/Json.hs
+++ b/lib/Entry/Json.hs
@@ -30,7 +30,7 @@ fieldConverter = prism' to from
         to field =
           A.object
           [ "date_modified" A..= (field ^. E.dateModified)
-          , "private" A..= (field ^. E.private)
+          , "visibility" A..= (field ^. E.visibility)
           , "value" A..= (field ^. E.value)
           ]
         from (A.Object o) = do
@@ -41,14 +41,10 @@ fieldConverter = prism' to from
                      >>= \case
                             A.String t -> Just t
                             _ -> Nothing
-          _private <- HS.lookup "private" o
-                        >>= \case
-                              A.Bool b -> Just b
-                              _ -> Nothing
-
+          _visibility <- HS.lookup "visibility" o >>= resultToMaybe . A.fromJSON
           pure
             $ E.newField dateModified value
-            & E.private .~ _private
+            & E.visibility .~ _visibility
         from _ = Nothing
 
 instance E.EntryConvertible JsonEntry where
@@ -91,3 +87,8 @@ instance E.EntryConvertible JsonEntry where
                   & E.fields .~ _fields
                   & E.tags .~ _tags
           from _ = Nothing
+
+resultToMaybe :: A.Result a -> Maybe a
+resultToMaybe = \case
+  A.Error _ -> Nothing
+  A.Success a -> Just a

--- a/package.yaml
+++ b/package.yaml
@@ -95,12 +95,15 @@ library:
     - http-types
     - lens
     - lens-aeson
+    - megaparsec
+    - optparse-applicative
     - polysemy
     - servant
     - servant-client
     - servant-client-core
     - text
     - time
+    - time-compat
     - tomland
     - unordered-containers
     - validation-selective

--- a/package.yaml
+++ b/package.yaml
@@ -87,6 +87,8 @@ library:
   dependencies:
     - aeson
     - containers
+    - extra
+    - fmt
     - hashable
     - http-client
     - http-client-tls

--- a/package.yaml
+++ b/package.yaml
@@ -104,7 +104,6 @@ library:
     - tomland
     - unordered-containers
     - validation-selective
-    - vector
 
 executables:
   coffer:


### PR DESCRIPTION
This PR implements the parsers needed for the CLI and adds a couple of newtypes for type-safety (`PathSegment`, `Path`, `EntryPath`, `FieldVisibility`).