### PR TITLE
[#3] Supported `view` command by default

### DIFF
--- a/lib/CLI/Parser.hs
+++ b/lib/CLI/Parser.hs
@@ -46,8 +46,8 @@ parserInfo =
     <> header "TODO: coffer description goes here"
 
 parser :: Parser SomeCommand
-parser =
-  subparser $ mconcat
+parser = 
+  subparser (mconcat
     [ mkCommand "view" CmdView viewOptions
         "View entries under the specified path, optionally returning only the specified field for each entry"
     , mkCommand "create" CmdCreate createOptions
@@ -66,13 +66,16 @@ parser =
         "Delete an entry or directory"
     , mkCommand "tag" CmdTag tagOptions
         "Add or remove tags from an entry"
-    ]
+    ]) <|> defaultCommandParser
   where
     mkCommand :: String -> (opts -> Command res) -> Parser opts -> String -> Mod CommandFields SomeCommand
     mkCommand cmdName constructor optsParser cmdHelp =
       command cmdName $
         info (helper <*> (SomeCommand . constructor <$> optsParser)) $
         progDesc cmdHelp
+
+    defaultCommandParser :: Parser SomeCommand
+    defaultCommandParser = SomeCommand . CmdView <$> viewOptions
 
 ----------------------------------------------------------------------------
 -- Options

--- a/lib/CLI/Parser.hs
+++ b/lib/CLI/Parser.hs
@@ -46,7 +46,7 @@ parserInfo =
     <> header "TODO: coffer description goes here"
 
 parser :: Parser SomeCommand
-parser = 
+parser =
   subparser (mconcat
     [ mkCommand "view" CmdView viewOptions
         "View entries under the specified path, optionally returning only the specified field for each entry"

--- a/tests/golden/view-command/view-command.bats
+++ b/tests/golden/view-command/view-command.bats
@@ -89,3 +89,19 @@ EOF
   assert_success
   assert_output "kek"
 }
+
+@test "view command by default" {
+  coffer create /a/b/c --field test=kek
+  coffer create /a/d
+
+  run cleanOutput coffer /a/b
+
+  assert_success
+  assert_output - <<EOF
+/
+  a/
+    b/
+      c - [2000-01-01 01:01:01]
+        test: kek [2000-01-01 01:01:01]
+EOF
+}


### PR DESCRIPTION
Problem: `view` will be the command users use the most. It would be better to make it the default command.
Solution: made `view` command by default.

[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)
- Fixes #3
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
