### PR TITLE
[#9] Directory check in `create` command

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -80,6 +80,8 @@ main = do
                 [ "An entry already exists at '" <> build path <> "'."
                 , "Use '--force' or '-f' to overwrite it."
                 ]
+              CRDirectoryAlreadyExists path -> printError $ "A directory already exists at '" <> build path <> "'."
+              CRParentPathContainsEntry path -> printError $ "An entry already exists at '" <> build path <> "'."
 
           SomeCommand cmd@(CmdSetField opts) -> do
             let fieldName = sfoFieldName opts

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -44,6 +44,8 @@ data ViewResult
 data CreateResult
   = CRSuccess Entry
   | CREntryAlreadyExists EntryPath
+  | CRDirectoryAlreadyExists EntryPath
+  | CRParentPathContainsEntry EntryPath
 
 data SetFieldResult
   = SFRSuccess Entry

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -14,6 +14,7 @@ module Coffer.Path
   , mkEntryPath
   , entryPathName
   , entryPathParentDir
+  , entryPathParentDirs
   , appendEntryName
   , pathAsEntryPath
   , entryPathAsPath
@@ -34,6 +35,7 @@ import qualified Data.List as List
 -- $setup
 -- >>> import Fmt (pretty, build)
 -- >>> import Control.Lens
+-- >>> import qualified Data.List.NonEmpty as NE
 -- >>> isRight (Right a) = a
 -- >>> unsafeMkPath = isRight . mkPath
 -- >>> unsafeMkEntryPath = isRight . mkEntryPath
@@ -125,6 +127,16 @@ entryPathName = view $ pathSegments . last1 . to unPathSegment
 entryPathParentDir :: Lens' EntryPath Path
 entryPathParentDir = pathSegments . initNE . from pathSegments
 
+-- | Gets all parents paths of given entry path.
+--
+-- >>> NE.toList (entryPathParentDirs (unsafeMkEntryPath "/dir1/dir2/entry")) <&> build
+-- ["/","/dir1","/dir1/dir2"]
+entryPathParentDirs :: EntryPath -> NonEmpty Path
+entryPathParentDirs entryPath =
+  entryPath ^. pathSegments
+    & NE.init
+    & NE.inits
+    <&> Path
 
 -- | Build an `EntryPath` by append the entry's name to its location path.
 --

--- a/tests/golden/create-command/create-command.bats
+++ b/tests/golden/create-command/create-command.bats
@@ -158,3 +158,21 @@ EOF
       second
 EOF
 }
+
+@test "creating an entry clashes with existing directory" {
+  coffer create /a/b/c
+
+  run coffer create /a/b
+
+  assert_failure
+  assert_output "[ERROR] A directory already exists at '/a/b'."
+}
+
+@test "creating a directory clashes with existing entry" {
+  coffer create /a/b
+
+  run coffer create /a/b/c
+
+  assert_failure
+  assert_output "[ERROR] An entry already exists at '/a/b'."
+}


### PR DESCRIPTION
Problem: we can create entries and directories with the same names.
Solution: added subfunction `checkForEntriesInEntryPath` which tries to find an existing entry subpath in given path. Then checked if the given entry path is an existing directory or contains existing entries in subpaths.

[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)
- Fixed #9
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
