### PR TITLE
[#38] Displaying fix in `set-field` command

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -90,9 +90,9 @@ main = do
             let field = entry ^?! E.fields . ix fieldName
             printSuccess $
               "Set field '" +| fieldName |+
-              "' to '" +| (field ^. E.value) |+
               "' (" +| (field ^. E.visibility) |+
-              ") at '" +| entry ^. E.path |+ "'."
+              ") at '" +| entry ^. E.path |+
+              "' to:\n" +| (field ^. E.value) |+ ""
 
       SomeCommand cmd@(CmdDeleteField opts) -> do
         runCommand config cmd >>= \case

--- a/tests/golden/find-command/find-command.bats
+++ b/tests/golden/find-command/find-command.bats
@@ -333,3 +333,18 @@ EOF
       c - [2000-01-01 01:01:01]
 EOF
 }
+
+@test "find multiline field" {
+  coffer create /path --field user="$(echo -e "first\nsecond")"
+
+  run cleanOutput coffer find
+
+  assert_success
+  assert_output - <<EOF
+/
+  path - [2000-01-01 01:01:01]
+    user: [2000-01-01 01:01:01]
+      first
+      second
+EOF
+}

--- a/tests/golden/set-field-command/set-field-command.bats
+++ b/tests/golden/set-field-command/set-field-command.bats
@@ -14,7 +14,10 @@ load '../helpers'
   run coffer set-field /a/b test aba -V public
 
   assert_success
-  assert_output "[SUCCESS] Set field 'test' to 'aba' (public) at '/a/b'."
+  assert_output - <<EOF
+[SUCCESS] Set field 'test' (public) at '/a/b' to:
+aba
+EOF
 
   run cleanOutput coffer find
   assert_output - <<EOF
@@ -27,7 +30,10 @@ EOF
   run coffer set-field /a/b test -V private
 
   assert_success
-  assert_output "[SUCCESS] Set field 'test' to 'aba' (private) at '/a/b'."
+  assert_output - <<EOF
+[SUCCESS] Set field 'test' (private) at '/a/b' to:
+aba
+EOF
 
   run cleanOutput coffer find
   assert_output - <<EOF
@@ -65,12 +71,18 @@ EOF
   run coffer set-field a kek a1
 
   assert_success
-  assert_output "[SUCCESS] Set field 'kek' to 'a1' (public) at '/a'."
+  assert_output - <<EOF
+[SUCCESS] Set field 'kek' (public) at '/a' to:
+a1
+EOF
 
   run coffer set-field a kek a2
 
   assert_success
-  assert_output "[SUCCESS] Set field 'kek' to 'a2' (public) at '/a'."
+  assert_output - <<EOF
+[SUCCESS] Set field 'kek' (public) at '/a' to:
+a2
+EOF
 
   run cleanOutput coffer view /
   assert_output - <<EOF
@@ -94,7 +106,10 @@ EOF
   run coffer set-field second#/a/b test test
 
   assert_success
-  assert_output "[SUCCESS] Set field 'test' to 'test' (public) at '/a/b'."
+  assert_output - <<EOF
+[SUCCESS] Set field 'test' (public) at '/a/b' to:
+test
+EOF
 
   run cleanOutput coffer view /
   assert_output - <<EOF

--- a/tests/golden/set-field-command/set-field-command.bats
+++ b/tests/golden/set-field-command/set-field-command.bats
@@ -126,3 +126,16 @@ EOF
       test: test [2000-01-01 01:01:01]
 EOF
 }
+
+@test "multiline field" {
+  coffer create /path
+
+  run coffer set-field /path multiline "$(echo -e "first\nsecond")"
+
+  assert_success
+  assert_output - <<EOF
+[SUCCESS] Set field 'multiline' (public) at '/path' to:
+first
+second
+EOF
+}

--- a/tests/golden/view-command/view-command.bats
+++ b/tests/golden/view-command/view-command.bats
@@ -119,3 +119,16 @@ EOF
     d - [2000-01-01 01:01:01]
 EOF
 }
+
+@test "view multiline fieldcontent" {
+  coffer create /path --field user="$(echo -e "first\n\nsecond")"
+
+  run coffer view /path user
+
+  assert_success
+  assert_output - <<EOF
+first
+
+second
+EOF
+}


### PR DESCRIPTION
[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description

### Problem
 `set-field` output is malformed when field contents are multiline.
### Solution 
Displaying output in `set-field` as @dcastro proposed.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)

- Fixes #38 

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
