### PR TITLE
[#48] Appending reset ANSI control sequences char after printing field value

### DIFF
--- a/coffer.cabal
+++ b/coffer.cabal
@@ -92,6 +92,7 @@ library
   ghc-options: -Weverything -Wno-implicit-prelude -Wno-name-shadowing -Wno-missing-import-lists -Wno-missing-export-lists -Wno-unsafe -Wno-safe -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-monomorphism-restriction -Wno-missed-specialisations -Wno-all-missed-specialisations
   build-depends:
       aeson
+    , ansi-terminal
     , base >=4.14.3.0 && <5
     , containers
     , extra

--- a/lib/Backend/Commands.hs
+++ b/lib/Backend/Commands.hs
@@ -24,7 +24,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 
 import Backend (BackendEffect, listSecrets, readSecret, writeSecret, deleteSecret, SomeBackend)
-import Entry (Entry, Field, FieldKey, value, fields, dateModified, newEntry, newField, visibility, FieldVisibility(..), EntryTag, path)
+import Entry (Entry, Field, FieldKey, value, fields, dateModified, newEntry, newField, visibility, FieldVisibility(..), EntryTag, path, fieldValue)
 import qualified Entry as E
 import Coffer.Directory (Directory)
 import qualified Coffer.Directory as Dir
@@ -187,7 +187,7 @@ findCmd config (FindOptions qPathMb textMb sortMb filters filterFields) = do
         Nothing -> False
         Just field ->
           case filter of
-            FilterFieldByValue substr -> substr `T.isInfixOf` (field ^. value)
+            FilterFieldByValue substr -> substr `T.isInfixOf` (field ^. value . fieldValue)
             FilterFieldByDate op date -> matchDate op date (field ^. dateModified)
 
   let path = maybe mempty qpPath qPathMb
@@ -231,6 +231,7 @@ findCmd config (FindOptions qPathMb textMb sortMb filters filterFields) = do
       . each
       . filtered (\field -> field ^. visibility == Private)
       . value
+      . fieldValue
       .~ "[private]"
 
     matchDate :: FilterOp -> FilterDate -> UTCTime -> Bool

--- a/lib/Backend/Vault/Kv.hs
+++ b/lib/Backend/Vault/Kv.hs
@@ -37,7 +37,7 @@ import           Polysemy
 import           Control.Lens
 import Coffer.Path (pathSegments, unPathSegment, HasPathSegments, PathSegment, EntryPath, Path)
 import qualified Data.Aeson.Text as A
-import Entry (FieldVisibility)
+import Entry (FieldVisibility, FieldValue (FieldValue))
 import Data.Either.Extra (eitherToMaybe, maybeToEither)
 import Data.Text (Text)
 import BackendName (BackendName, backendNameCodec)
@@ -170,7 +170,7 @@ kvWriteSecret backend entry = do
       { I.psCas = Nothing
       , I.psDdata =
               HS.insert "#$coffer" (TL.toStrict $ A.encodeToLazyText cofferSpecials)
-            . HS.map (^. E.value)
+            . HS.map (^. E.value . E.fieldValue)
             . HS.mapKeys E.getFieldKey
             $ entry ^. E.fields
         }
@@ -195,7 +195,7 @@ kvReadSecret backend path = do
             _key <- eitherToMaybe $ E.newFieldKey key
 
             Just (_key
-                  , E.newField _modTime value
+                  , E.newField _modTime (FieldValue value)
                     & E.visibility .~ _visibility
                   )
 

--- a/lib/CLI/Parser.hs
+++ b/lib/CLI/Parser.hs
@@ -33,7 +33,7 @@ import Data.Bifunctor (first)
 import qualified Data.Set as Set
 
 import CLI.Types
-import Entry (FieldKey, EntryTag, newEntryTag, newFieldKey, FieldVisibility (Public, Private))
+import Entry (FieldKey, EntryTag, newEntryTag, newFieldKey, FieldVisibility (Public, Private), FieldValue (FieldValue))
 import Coffer.Path (Path, mkPath, EntryPath, mkEntryPath, QualifiedPath (QualifiedPath))
 import BackendName (newBackendName, BackendName)
 
@@ -165,7 +165,7 @@ setFieldOptions =
           [ metavar "FIELDNAME"
           , help "The name of the field to set"
           ])
-    <*> optional (argument str $ mconcat
+    <*> optional (argument readFieldValue $ mconcat
           [ metavar "FIELDCONTENTS"
           , help "The contents to insert into the field. Required when creating a new field, optional otherwise"
           ])
@@ -397,6 +397,9 @@ readQualifiedPath = do
                 , show expectedQualifiedPathFormat
                 ]
 
+readFieldValue :: ReadM FieldValue
+readFieldValue = str <&> FieldValue
+
 readFieldInfo :: ReadM FieldInfo
 readFieldInfo = do
   eitherReader \input ->
@@ -612,8 +615,8 @@ parseFieldNameWhile whileCond = do
   either fail pure $ readFieldKey' fieldName
 
 -- | Parse the rest of the input as a field content.
-parseFieldContentsEof :: MParser Text
-parseFieldContentsEof = T.pack <$> P.manyTill P.anySingle P.eof
+parseFieldContentsEof :: MParser FieldValue
+parseFieldContentsEof = FieldValue . T.pack <$> P.manyTill P.anySingle P.eof
 
 ----------------------------------------------------------------------------
 -- Utils

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -7,7 +7,7 @@ module CLI.Types where
 import Data.Text (Text)
 import Data.Time.Compat (Day, UTCTime , Year)
 import Data.Time.Calendar.Month.Compat (Month)
-import Entry (FieldKey, Field, Entry, FieldVisibility, EntryTag)
+import Entry (FieldKey, Field, Entry, FieldVisibility, EntryTag, FieldValue)
 import Coffer.Directory (Directory)
 import Coffer.Path (Path, EntryPath, QualifiedPath)
 import Data.Set (Set)
@@ -109,7 +109,7 @@ data CreateOptions = CreateOptions
 data SetFieldOptions = SetFieldOptions
   { sfoQPath :: QualifiedPath EntryPath
   , sfoFieldName :: FieldKey
-  , sfoFieldContents :: Maybe Text
+  , sfoFieldContents :: Maybe FieldValue
   , sfoVisibility :: Maybe FieldVisibility
   }
   deriving stock Show
@@ -165,7 +165,7 @@ data TagOptions = TagOptions
 
 data FieldInfo = FieldInfo
   { fiName :: FieldKey
-  , fiContents :: Text
+  , fiContents :: FieldValue
   }
   deriving stock Show
 

--- a/lib/Entry/Json.hs
+++ b/lib/Entry/Json.hs
@@ -13,7 +13,7 @@ import qualified Data.HashMap.Strict as HS
 import qualified Data.Text as T
 import Data.Time.Format.ISO8601 (iso8601ParseM)
 import Control.Monad (forM)
-import Entry (Entry)
+import Entry (Entry, FieldValue (FieldValue))
 import Fmt (pretty)
 import qualified Coffer.Path as Path
 import Data.Either.Extra (eitherToMaybe)
@@ -29,7 +29,7 @@ fieldConverter = prism' to from
           A.object
           [ "date_modified" A..= (field ^. E.dateModified)
           , "visibility" A..= (field ^. E.visibility)
-          , "value" A..= (field ^. E.value)
+          , "value" A..= (field ^. E.value . E.fieldValue)
           ]
         from (A.Object o) = do
           dateModified <- HS.lookup "date_modified" o
@@ -41,7 +41,7 @@ fieldConverter = prism' to from
                             _ -> Nothing
           _visibility <- HS.lookup "visibility" o >>= resultToMaybe . A.fromJSON
           pure
-            $ E.newField dateModified value
+            $ E.newField dateModified (FieldValue value)
             & E.visibility .~ _visibility
         from _ = Nothing
 

--- a/package.yaml
+++ b/package.yaml
@@ -87,6 +87,7 @@ library:
   source-dirs:      lib
   dependencies:
     - aeson
+    - ansi-terminal
     - containers
     - extra
     - extra

--- a/tests/golden/find-command/find-command.bats
+++ b/tests/golden/find-command/find-command.bats
@@ -348,3 +348,21 @@ EOF
       second
 EOF
 }
+
+@test "'find' resets all ANSI control sequences" {
+  coffer create /a/b/c --field x="$(echo -e "\x1b[41;1mHi i'm red")"
+  coffer create /a/b/d --field x=y
+
+  run cleanOutput coffer find
+
+  assert_success
+  assert_output - <<EOF
+/
+  a/
+    b/
+      c - [2000-01-01 01:01:01]
+        x: $(printf '\x1b[41;1m')Hi i'm red$reset [2000-01-01 01:01:01]
+      d - [2000-01-01 01:01:01]
+        x: y [2000-01-01 01:01:01]
+EOF
+}

--- a/tests/golden/helpers.bash
+++ b/tests/golden/helpers.bash
@@ -22,3 +22,6 @@ setup () {
 cleanOutput () {
   $@ | sed -r 's/\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\]$/[2000-01-01 01:01:01]/g'
 }
+
+# Reset ANSI control sequences char.
+reset=$(printf '\x1b[0m')

--- a/tests/golden/set-field-command/set-field-command.bats
+++ b/tests/golden/set-field-command/set-field-command.bats
@@ -139,3 +139,15 @@ first
 second
 EOF
 }
+
+@test "set field with ANSI control sequences" {
+  coffer create /a/b/c
+
+  run coffer set-field /a/b/c red "$(echo -e "\x1b[41;1mHi I'm red")"
+
+  assert_success
+  assert_output - <<EOF
+[SUCCESS] Set field 'red' (public) at '/a/b/c' to:
+$(printf '\x1b[41;1m')Hi I'm red$reset
+EOF
+}

--- a/tests/golden/view-command/view-command.bats
+++ b/tests/golden/view-command/view-command.bats
@@ -132,3 +132,30 @@ first
 second
 EOF
 }
+
+@test "view entry with ANSI control sequences" {
+  coffer create /a/b/c --field x="$(echo -e "\x1b[41;1mHi i'm red")"
+  coffer create /a/b/d --field x=y
+
+  run cleanOutput coffer view /
+
+  assert_success
+  assert_output - <<EOF
+/
+  a/
+    b/
+      c - [2000-01-01 01:01:01]
+        x: $(printf '\x1b[41;1m')Hi i'm red$reset [2000-01-01 01:01:01]
+      d - [2000-01-01 01:01:01]
+        x: y [2000-01-01 01:01:01]
+EOF
+}
+
+@test "view field with ANSI control sequences" {
+  coffer create /a/b/c --field x="$(echo -e "\x1b[41;1mHi i'm red")"
+
+  run coffer view /a/b/c x
+
+  assert_success
+  assert_output "$(printf '\x1b[41;1m')Hi i'm red$reset"
+}


### PR DESCRIPTION
[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description

### Problem 
Field contents may contain ANSI control sequences and they can affect other fields.

### Solution
Wrapped field value in newtype `FieldValue` and created the `Buildable` instance for it
which appends reset ANSI control sequences char to field value.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)

- Fixes #48

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
