### PR TITLE
[#52] Show qualified paths in `coffer` messages

### DIFF
--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -44,45 +44,45 @@ data ViewResult
   = VRDirectory Directory
   | VREntry Entry
   | VRField FieldKey Field
-  | VRPathNotFound Path
-  | VRDirectoryNoFieldMatch Path FieldKey
-  | VREntryNoFieldMatch EntryPath FieldKey
+  | VRPathNotFound (QualifiedPath Path)
+  | VRDirectoryNoFieldMatch (QualifiedPath Path) FieldKey
+  | VREntryNoFieldMatch (QualifiedPath EntryPath) FieldKey
 
 data CreateError
-  = CEParentDirectoryIsEntry (Entry, EntryPath)
-  | CEDestinationIsDirectory Entry
-  | CEEntryAlreadyExists Entry
+  = CEParentDirectoryIsEntry (QualifiedPath EntryPath, QualifiedPath EntryPath)
+  | CEDestinationIsDirectory (QualifiedPath EntryPath)
+  | CEEntryAlreadyExists (QualifiedPath EntryPath)
 
 data CreateResult
   = CRSuccess Entry
   | CRCreateError CreateError
 
 data SetFieldResult
-  = SFRSuccess Entry
-  | SFREntryNotFound EntryPath
-  | SFRMissingFieldContents EntryPath
+  = SFRSuccess (QualifiedPath Entry)
+  | SFREntryNotFound (QualifiedPath EntryPath)
+  | SFRMissingFieldContents (QualifiedPath EntryPath)
 
 data DeleteFieldResult
   = DFRSuccess Entry
-  | DFREntryNotFound EntryPath
+  | DFREntryNotFound (QualifiedPath EntryPath)
   | DFRFieldNotFound FieldKey
 
 type RenameResult = CopyResult
 
 data CopyResult
-  = CPRSuccess [(EntryPath, EntryPath)]
-  | CPRPathNotFound Path
+  = CPRSuccess [(QualifiedPath EntryPath, QualifiedPath EntryPath)]
+  | CPRPathNotFound (QualifiedPath Path)
   | CPRMissingEntryName
-  | CPRCreateErrors [(EntryPath, CreateError)]
+  | CPRCreateErrors [(QualifiedPath EntryPath, CreateError)]
 
 data DeleteResult
-  = DRSuccess [EntryPath]
-  | DRPathNotFound Path
-  | DRDirectoryFound Path
+  = DRSuccess [QualifiedPath EntryPath]
+  | DRPathNotFound (QualifiedPath Path)
+  | DRDirectoryFound (QualifiedPath Path)
 
 data TagResult
   = TRSuccess Entry
-  | TREntryNotFound EntryPath
+  | TREntryNotFound (QualifiedPath EntryPath)
   | TRTagNotFound EntryTag
   | TRDuplicateTag EntryTag
 

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -177,7 +177,7 @@ data QualifiedPath path = QualifiedPath
   { qpBackendName :: Maybe BackendName
   , qpPath :: path
   }
-  deriving stock (Show)
+  deriving stock (Show, Functor)
 
 instance (Buildable path) => Buildable (QualifiedPath path) where
   build (QualifiedPath backendNameMb path) =

--- a/tests/golden/copy-command/copy-command.bats
+++ b/tests/golden/copy-command/copy-command.bats
@@ -261,7 +261,7 @@ EOF
   run coffer copy /a second#/c
 
   assert_success
-  assert_output "[SUCCESS] Copied '/a/b' to '/c/b'."
+  assert_output "[SUCCESS] Copied '/a/b' to 'second#/c/b'."
 
   run cleanOutput coffer view /
   assert_output - <<EOF

--- a/tests/golden/delete-command/delete-command.bats
+++ b/tests/golden/delete-command/delete-command.bats
@@ -95,7 +95,7 @@ EOF
   run coffer delete second#/a/b
 
   assert_success
-  assert_output "[SUCCESS] Deleted '/a/b'."
+  assert_output "[SUCCESS] Deleted 'second#/a/b'."
 
   run cleanOutput coffer view /
   assert_output - <<EOF

--- a/tests/golden/rename-command/rename-command.bats
+++ b/tests/golden/rename-command/rename-command.bats
@@ -235,7 +235,7 @@ EOF
   run coffer rename /a second#/c
 
   assert_success
-  assert_output "[SUCCESS] Renamed '/a/b' to '/c/b'."
+  assert_output "[SUCCESS] Renamed '/a/b' to 'second#/c/b'."
 
   run cleanOutput coffer view /
   assert_output - <<EOF

--- a/tests/golden/set-field-command/set-field-command.bats
+++ b/tests/golden/set-field-command/set-field-command.bats
@@ -107,7 +107,7 @@ EOF
 
   assert_success
   assert_output - <<EOF
-[SUCCESS] Set field 'test' (public) at '/a/b' to:
+[SUCCESS] Set field 'test' (public) at 'second#/a/b' to:
 test
 EOF
 


### PR DESCRIPTION
[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description

### Problem
`coffer` messages don't show backend name in paths. Sometimes
we need it. For e.g.
````
coffer copy 'b1#/a' 'b2#/a'
[SUCCESS] Copied '/a/b' to '/a/b'.
````
It looks very odd.

### Solution
Supported qualified paths in `coffer` messages. Now example
above would print next
````
coffer copy 'b1#/a' 'b2#/a'
[SUCCESS] Copied 'b1#/a/b' to 'b2#/a/b'.
````

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)
- Fixes #52 
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
