### PR TITLE
[#49] Escaping characters in parse errors

### DIFF
--- a/lib/CLI/Parser.hs
+++ b/lib/CLI/Parser.hs
@@ -317,14 +317,14 @@ tagOptions =
 readPath' :: Text -> Either String Path
 readPath' input =
   mkPath input & first \err -> unlines
-    [ "Invalid path: '" <> T.unpack input <> "'."
+    [ "Invalid path: " <> show input <> "."
     , T.unpack err
     ]
 
 readEntryPath' :: Text -> Either String EntryPath
 readEntryPath' input =
   mkEntryPath input & first \err -> unlines
-    [ "Invalid entry path: '" <> T.unpack input <> "'."
+    [ "Invalid entry path: " <> show input <> "."
     , T.unpack err
     ]
 
@@ -335,14 +335,14 @@ readEntryTag :: ReadM EntryTag
 readEntryTag = do
   eitherReader \input ->
     newEntryTag (T.pack input) & first \err -> unlines
-      [ "Invalid tag: '" <> input <> "'."
+      [ "Invalid tag: " <> show input <> "."
       , T.unpack err
       ]
 
 readBackendName' :: Text -> Either String BackendName
 readBackendName' input =
   newBackendName input & first \err -> unlines
-    [ "Invalid backend name: '" <> T.unpack input <> "'."
+    [ "Invalid backend name: " <> show input <> "."
     , T.unpack err
     ]
 
@@ -361,7 +361,7 @@ readFieldKey' input = do
   case newFieldKey input of
     Right tag -> pure tag
     Left err -> Left $ unlines
-      [ "Invalid field name: '" <> T.unpack input <> "'."
+      [ "Invalid field name: " <> show input <> "."
       , T.unpack err
       ]
 
@@ -378,7 +378,7 @@ readQualifiedEntryPath = do
         pure $ QualifiedPath Nothing entryPath
       _ ->
         Left $ unlines
-                [ "Invalid qualified entry path format: '" <> input <> "'."
+                [ "Invalid qualified entry path format: " <> show input <> "."
                 , show expectedQualifiedEntryPathFormat
                 ]
 
@@ -395,7 +395,7 @@ readQualifiedPath = do
         pure $ QualifiedPath Nothing path
       _ ->
         Left $ unlines
-                [ "Invalid qualified entry path format: '" <> input <> "'."
+                [ "Invalid qualified path format: " <> show input <> "."
                 , show expectedQualifiedPathFormat
                 ]
 
@@ -406,7 +406,7 @@ readFieldInfo :: ReadM FieldInfo
 readFieldInfo = do
   eitherReader \input ->
     P.parse (parseFieldInfo <* P.eof) "" (T.pack input) & first \err -> unlines
-      [ "Invalid field format: '" <> input <> "'."
+      [ "Invalid field format: " <> show input <> "."
       , "Expected format: 'fieldname=fieldcontents'."
       , ""
       , "Parser error:"
@@ -423,7 +423,7 @@ readSort = do
           "name" -> pure (SortByEntryName, direction')
           "date" -> pure (SortByEntryDate, direction')
           _ -> Left $ unlines
-            [ "Invalid sort: '" <> T.unpack means <> "'."
+            [ "Invalid sort: " <> show means <> "."
             , "Choose one of: 'name', 'date'."
             , ""
             , show expectedSortFormat
@@ -435,13 +435,13 @@ readSort = do
           "value" -> pure (SortByFieldValue fieldName', direction')
           "date" -> pure (SortByFieldDate fieldName', direction')
           _ -> Left $ unlines
-            [ "Invalid sort: '" <> T.unpack means <> "'."
+            [ "Invalid sort: " <> show means <> "."
             , "Choose one of: 'value', 'date'."
             , ""
             , show expectedSortFormat
             ]
       _ -> Left $ unlines
-        [ "Invalid sort format: '" <> input <> "'."
+        [ "Invalid sort format: " <> show input <> "."
         , show expectedSortFormat
         ]
 
@@ -467,7 +467,7 @@ readFilter :: ReadM Filter
 readFilter = do
   eitherReader \input ->
     P.parse (parseFilter <* P.eof) "" (T.pack input) & first \err -> unlines
-      [ "Invalid filter format: '" <> input <> "'."
+      [ "Invalid filter format: " <> show input <> "."
       , show expectedFilterFormat
       , ""
       , "Parser error:"
@@ -500,7 +500,7 @@ readFilterField :: ReadM (FieldKey, FilterField)
 readFilterField = do
   eitherReader \input ->
     P.parse (parseFilterField <* P.eof) "" (T.pack input) & first \err -> unlines
-      [ "Invalid filter-field format: '" <> input <> "'."
+      [ "Invalid filter-field format: " <> show input <> "."
       , show expectedFilterFieldFormat
       , ""
       , "Parser error:"

--- a/tests/golden/common/common.bats
+++ b/tests/golden/common/common.bats
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+#!/usr/bin/env bats
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers'
+
+@test "bad path" {
+  run coffer view "$(echo -e "bad\npath")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+Invalid path: "bad\npath".
+Path segments can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
+EOF
+}
+
+@test "bad entry path" {
+  run coffer create "$(echo -e "bad/entry\npath")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+Invalid entry path: "bad/entry\npath".
+Path segments can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
+EOF
+}
+
+@test "bad entry tag" {
+  run coffer tag /path "$(echo -e "bad\ntag")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+Invalid tag: "bad\ntag".
+Tags can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'
+EOF
+}
+
+@test "bad backend name" {
+  run coffer create "$(echo -e "bad\nbackend#/path")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+Invalid backend name: "bad\nbackend".
+Backend name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'
+EOF
+}
+
+@test "bad field key" {
+  run coffer view /path "$(echo -e "bad\nfieldkey")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+Invalid field name: "bad\nfieldkey".
+Tags can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'
+EOF
+}
+
+@test "bad qualified entry path" {
+  run coffer create "$(echo -e "back#/path#\n\nsmth")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+Invalid qualified entry path format: "back#/path#\n\nsmth".
+Expected format is: [<backend-name>#]<entry-path>.
+<backend-name> can be a string of the following characters: [a-zA-Z0-9] and symbols '-', '_', ';'.
+Examples: 'vault_kv-backend#secrets/google', 'my/passwords/entry'.
+EOF
+}
+
+@test "bad qualified path" {
+  run coffer view "$(echo -e "back#/path#\n\nsmth")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+Invalid qualified path format: "back#/path#\n\nsmth".
+Expected format is: [<backend-name>#]<path>.
+<backend-name> can be a string of the following characters: [a-zA-Z0-9] and symbols '-', '_', ';'.
+Examples: 'vault_kv-backend#secrets/google', 'my/passwords/mypage/'.
+EOF
+}
+
+@test "bad field info" {
+  run coffer create /path --field "$(echo -e "bad\n\n=test")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+option --field: Invalid field format: "bad\n\n=test".
+Expected format: 'fieldname=fieldcontents'.
+
+Parser error:
+1:4:
+  |
+1 | bad
+  |    ^
+unexpected newline
+expecting '=', fieldname, or white space
+EOF
+}
+
+@test "bad filter" {
+  run coffer find --filter "$(echo -e "bad\nfilter~str")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+option --filter: Invalid filter format: "bad\nfilter~str".
+EOF
+}
+
+@test "bad filter field" {
+  run coffer find --filter-field "$(echo -e "name:bad\n\n~str")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+option --filter-field: Invalid filter-field format: "name:bad\n\n~str".
+EOF
+}

--- a/tests/golden/create-command/create-command.bats
+++ b/tests/golden/create-command/create-command.bats
@@ -13,7 +13,7 @@ load '../helpers'
 
   assert_failure
   assert_output --partial - <<EOF
-Invalid entry path: '/'.
+Invalid entry path: "/".
 Entry paths must not be empty.
 EOF
 }
@@ -68,7 +68,7 @@ EOF
 
   assert_failure
   assert_output --partial - <<EOF
-option --field: Invalid field format: '=johndoe@gmail.com'.
+option --field: Invalid field format: "=johndoe@gmail.com".
 Expected format: 'fieldname=fieldcontents'.
 
 Parser error:


### PR DESCRIPTION
[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description

### Problem
We are not escaping failing input in parse errors.
Some characters can be invisible (e.g. zero width space) so user
can't figure out what is going on when he sees parse error.

### Solution
Escaping failing input in parse errors.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)
- Fixes #49 
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
