### PR TITLE
[#24] Better error handling

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -39,7 +39,7 @@ runBackendIO action =
     >>= \case
       Right a -> pure a
       Left err -> do
-        die $ show err
+        die $ pretty err
 
 readConfig :: FilePath -> IO Config
 readConfig configPath = do

--- a/lib/Backend/Commands.hs
+++ b/lib/Backend/Commands.hs
@@ -37,7 +37,7 @@ import Entry
   newEntry, newField, path, value, visibility)
 import Entry qualified as E
 import Error (CofferError(..))
-import Fmt (pretty)
+import Fmt (Builder, pretty, unlinesF)
 import GHC.Exts (Down(..), sortWith)
 import Polysemy
 import Polysemy.Error (Error, throw)
@@ -350,7 +350,7 @@ buildCopyOperations oldBackend newBackend oldQPath@(QualifiedPath oldBackendName
         newEntry <- entry & E.path . Path.entryPathParentDir %%~ \parentDir ->
           case Path.replacePathPrefix oldPath newPath parentDir of
             Just newParentDir -> pure newParentDir
-            Nothing -> throw $ OtherError $ T.unlines
+            Nothing -> throw $ OtherError $ unlinesF @_ @Builder
               [ "Internal error:"
               , "Expected path: '" <> pretty (entry ^. E.path) <> "'"
               , "To have the prefix: '" <> pretty oldPath <> "'"
@@ -531,7 +531,7 @@ getEntryOrDir backend path =
                   Nothing -> pure ()
 
               (_, Right subdir) -> go (rootPath <> subdir)
-              _ -> lift $ throw $ OtherError $ T.unlines
+              _ -> lift $ throw $ OtherError $ unlinesF
                     [ "Internal error:"
                     , "Backend returned a secret that is not a valid\
                       \ entry or directory name."

--- a/lib/Backend/Vault/Kv.hs
+++ b/lib/Backend/Vault/Kv.hs
@@ -12,12 +12,13 @@ import Backend.Vault.Kv.Internal qualified as I
 import BackendName (BackendName, backendNameCodec)
 import Coffer.Path (EntryPath, HasPathSegments, Path, PathSegment, pathSegments, unPathSegment)
 import Coffer.Util (didimatch)
-import Control.Exception (catch)
+import Control.Exception (try)
 import Control.Lens hiding ((.=))
 import Control.Monad (void)
 import Data.Aeson qualified as A
 import Data.Aeson.Text qualified as A
-import Data.Either.Extra (eitherToMaybe, maybeToEither)
+import Data.Bifunctor (first)
+import Data.Either.Extra (maybeToEither)
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HS
 import Data.Set (Set)
@@ -27,9 +28,10 @@ import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Text.Lazy qualified as TL
 import Data.Time (UTCTime)
-import Entry (Entry, FieldValue(FieldValue), FieldVisibility)
+import Entry (Entry, Field, FieldKey, FieldValue(FieldValue), FieldVisibility)
 import Entry qualified as E
 import Error (CofferError(..))
+import Fmt
 import GHC.Generics (Generic)
 import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
@@ -99,33 +101,15 @@ getEnv backend =
   where
     url = vbAddress backend
 
--- | Handles @ClientError@ in the following way:
--- 1. If it is @FailureResponse@ and status code isn't 404, then we would get an error.
---    It status code is 404, the result would be Nothing
--- 2. If it is @ConnectionError@, then we would get @ConnectError@
--- 3. Otherwise we would get @MarshallingFailed@
-exceptionHandler :: ClientError -> Maybe CofferError
-exceptionHandler = \case
-  FailureResponse _request response ->
-    case statusCode $ responseStatusCode response of
-      404 -> Nothing
-      e -> Just $ OtherError (T.pack $ show e)
-  DecodeFailure _ _ -> Just MarshallingFailed
-  UnsupportedContentType _ _ -> Just MarshallingFailed
-  InvalidContentTypeHeader _ -> Just MarshallingFailed
-  ConnectionError _ -> Just ConnectError
-
 -- | Runs an IO action and throws an error if happens.
 embedCatchClientError
   :: Member (Embed IO) r
   => Member (Error CofferError) r
   => IO a
   -> Sem r a
-embedCatchClientError io =
-  embed (catch @ClientError (io <&> Left) (pure . Right . exceptionHandler)) >>= \case
-    Left l -> pure l
-    Right (Just r) -> throw r
-    Right Nothing -> throw $ OtherError "404"
+embedCatchClientError io = embed (try @ClientError io) >>= \case
+  Left err -> throw $ ServantError err
+  Right r -> pure r
 
 -- | Runs an IO action and throws an error only if it isn't a failure response with status code 404.
 --   Otherwise, it would be Nothing.
@@ -134,18 +118,18 @@ embedCatchClientErrorMaybe
   => Member (Error CofferError) r
   => IO a
   -> Sem r (Maybe a)
-embedCatchClientErrorMaybe io =
-  embed (catch @ClientError (io <&> Left) (pure . Right . exceptionHandler)) >>= \case
-    Left l -> (pure . Just) l
-    Right (Just r) -> throw r
-    Right Nothing -> pure Nothing
+embedCatchClientErrorMaybe io = embed (try @ClientError io) >>= \case
+  Left (FailureResponse _ response)
+    | statusCode (responseStatusCode response) == 404 -> pure Nothing
+  Left err -> throw $ ServantError err
+  Right r -> pure $ Just r
 
-orThrow
-  :: Member (Error e) r
-  => Maybe a
-  -> e
+orThrowEither
+  :: Member (Error err) r
+  => Either e a
+  -> (e -> err)
   -> Sem r a
-orThrow m e = maybe (throw e) pure m
+orThrowEither e mkErr = either (throw . mkErr) pure e
 
 getPathSegments
   :: (HasPathSegments s segments, Each segments segments PathSegment PathSegment)
@@ -183,42 +167,50 @@ kvWriteSecret backend entry = do
   where
     postSecret env = (I.routes env ^. I.postSecret) (vbMount backend) (vbToken backend)
 
-kvReadSecret :: Effects r => VaultKvBackend -> EntryPath -> Sem r (Maybe Entry)
+kvReadSecret :: forall r. Effects r => VaultKvBackend -> EntryPath -> Sem r (Maybe E.Entry)
 kvReadSecret backend path = do
   env <- getEnv backend
   embedCatchClientErrorMaybe (readSecret env (getPathSegments path) Nothing) >>= \case
     Nothing -> pure Nothing
     Just (I.KvResponse _ _ _ _ (I.ReadSecret _data _ _ _ _ _)) -> do
-      cofferSpecials :: CofferSpecials <-
-        (_data ^.at "#$coffer" >>= A.decodeStrict' . T.encodeUtf8) `orThrow` MarshallingFailed
-      let secrets = HS.toList $ HS.delete "#$coffer" _data
-      let keyAndValueToField (key, value) = do
-            _modTime <- cofferSpecials ^? fields . at key . _Just . dateModified
-            _visibility <- cofferSpecials ^? fields . at key . _Just . visibility
-            _key <- eitherToMaybe $ E.newFieldKey key
+      cofferSpecials <- do
+        case _data ^. at "#$coffer" of
+          Nothing ->
+            throw (OtherError $ "Could not find key '#$coffer' in the kv entry at '" +| path |+ "'.")
+          Just txt ->
+            txt
+              & A.eitherDecodeStrict' @CofferSpecials . T.encodeUtf8
+              & first build
+              & (`orThrowEither` OtherError)
 
-            Just
-              (_key
-              , E.newField _modTime (FieldValue value)
-                & E.visibility .~ _visibility
-              )
+      let secrets = HS.toList $ HS.delete "#$coffer" _data
 
       fields <-
-        (secrets & each %%~ keyAndValueToField <&> HS.fromList) `orThrow` MarshallingFailed
+        secrets
+          & each %%~ keyAndValueToField cofferSpecials
+          <&> HS.fromList
+
       _tags <- cofferSpecials ^. tags
-        & Set.toList
-        & mapM E.newEntryTag
-        <&> Set.fromList
-        & eitherToMaybe
-        & (`orThrow` MarshallingFailed)
+            & Set.toList
+            & mapM E.newEntryTag
+            <&> Set.fromList
+            & first build
+            & (`orThrowEither` OtherError)
 
       fieldKey <-
         case cofferSpecials ^. masterKey of
           Nothing -> pure Nothing
           Just mKey ->
-            case eitherToMaybe $ E.newFieldKey mKey of
-              Nothing -> throw (OtherError $ "Attempted to create new field key from '" <> mKey <> "'")
-              Just fieldKey -> (pure . Just) fieldKey
+            case E.newFieldKey mKey of
+              Left err ->
+                throw
+                  ( OtherError $ unlinesF
+                      [ "Attempted to create new field key from '" <> mKey <> "'"
+                      , ""
+                      , err
+                      ]
+                  )
+              Right fieldKey -> (pure . Just) fieldKey
 
       pure . Just
         $ E.newEntry path (cofferSpecials ^. globalDateModified)
@@ -228,7 +220,28 @@ kvReadSecret backend path = do
   where
     readSecret env = (I.routes env ^. I.readSecret) (vbMount backend) (vbToken backend)
 
-kvListSecrets :: Effects r => VaultKvBackend -> Path -> Sem r (Maybe [Text])
+    keyAndValueToField :: CofferSpecials -> (Text, Text) -> Sem r (FieldKey, Field)
+    keyAndValueToField cofferSpecials (fieldKey, value) = do
+      metadata <- maybe (throw $ OtherError metadataNotFound) pure (cofferSpecials ^. fields . at fieldKey)
+      let _modTime = metadata ^. dateModified
+      let _visibility = metadata ^. visibility
+      _fieldKey <-
+        fieldKey
+          & E.newFieldKey
+          & first build
+          & (`orThrowEither` OtherError)
+
+      pure (_fieldKey
+           , E.newField _modTime (FieldValue value)
+              & E.visibility .~ _visibility
+           )
+      where
+        metadataNotFound :: Builder
+        metadataNotFound =
+          "Could not find coffer metadata for field '" +| fieldKey
+            |+ "' at '" +| path |+ "'"
+
+kvListSecrets :: Effects r => VaultKvBackend -> Path -> Sem r (Maybe [T.Text])
 kvListSecrets backend path = do
   env <- getEnv backend
   embedCatchClientErrorMaybe do


### PR DESCRIPTION
[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description

### Problem
In `Backend.Vault.Kv` error handling is very bad. We
lose a lot of info about thrown exceptions.

### Solution
Added more `CofferError` constructors (e.g. `RequestFailed` and `DecodeFailed`)
which stores all necessary information and wrote `Buildable` instance for it.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)
- Fixes #24 
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
