### PR TITLE
[#72] Backend-agnostic `CofferError` GADT

### DIFF
--- a/lib/CLI/Parser.hs
+++ b/lib/CLI/Parser.hs
@@ -32,6 +32,7 @@ import Data.Void (Void)
 import Entry
   (EntryTag, FieldKey, FieldValue(FieldValue), FieldVisibility(Private, Public), newEntryTag,
   newFieldKey)
+import Fmt (pretty)
 import Options.Applicative
 import Options.Applicative.Help.Pretty qualified as Pretty
 import Text.Megaparsec qualified as P
@@ -350,7 +351,7 @@ readEntryTag = do
   eitherReader \input ->
     newEntryTag (T.pack input) & first \err -> unlines
       [ "Invalid tag: " <> show input <> "."
-      , T.unpack err
+      ,  pretty err
       ]
 
 readBackendName' :: Text -> Either String BackendName
@@ -376,7 +377,7 @@ readFieldKey' input = do
     Right tag -> pure tag
     Left err -> Left $ unlines
       [ "Invalid field name: " <> show input <> "."
-      , T.unpack err
+      , pretty err
       ]
 
 readQualifiedEntryPath :: ReadM (QualifiedPath EntryPath)

--- a/lib/Entry.hs
+++ b/lib/Entry.hs
@@ -4,10 +4,12 @@
 
 module Entry
   ( FieldKey
+  , BadFieldName (..)
   , keyCharSet
   , newFieldKey
   , getFieldKey
   , EntryTag
+  , BadEntryTag (..)
   , newEntryTag
   , getEntryTag
   , FieldVisibility(..)
@@ -50,12 +52,15 @@ newtype FieldKey = UnsafeFieldKey Text
 keyCharSet :: [Char]
 keyCharSet = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ "-_;"
 
-newFieldKey :: Text -> Either Text FieldKey
+newtype BadFieldName = BadFieldName { unBadFieldName :: Text }
+  deriving newtype Buildable
+
+newFieldKey :: Text -> Either BadFieldName FieldKey
 newFieldKey t
   | T.null t =
-      Left "Tags must contain at least 1 character"
+      Left $ BadFieldName "Tags must contain at least 1 character"
   | T.any (`notElem` keyCharSet) t =
-      Left $ "Tags can only contain the following characters: '" <> T.pack keyCharSet <> "'"
+      Left $ BadFieldName ("Tags can only contain the following characters: '" <> T.pack keyCharSet <> "'")
   | otherwise = Right $ UnsafeFieldKey t
 
 getFieldKey :: FieldKey -> Text
@@ -65,12 +70,15 @@ newtype EntryTag = UnsafeEntryTag Text
   deriving stock (Show, Eq, Ord)
   deriving newtype (A.ToJSON, A.FromJSON, Buildable)
 
-newEntryTag :: Text -> Either Text EntryTag
+newtype BadEntryTag = BadEntryTag { unBadEntryTag :: Text }
+  deriving newtype Buildable
+
+newEntryTag :: Text -> Either BadEntryTag EntryTag
 newEntryTag tag
   | T.null tag =
-      Left "Tags must contain at least 1 character"
+      Left $ BadEntryTag "Tags must contain at least 1 character"
   | T.any (`notElem` keyCharSet) tag =
-      Left $ "Tags can only contain the following characters: '" <> T.pack keyCharSet <> "'"
+      Left $ BadEntryTag ("Tags can only contain the following characters: '" <> T.pack keyCharSet <> "'")
   | otherwise = Right $ UnsafeEntryTag tag
 
 getEntryTag :: EntryTag -> Text

--- a/lib/Error.hs
+++ b/lib/Error.hs
@@ -4,55 +4,67 @@
 
 module Error
   ( CofferError (..)
+  , BackendError
+  , InternalCommandsError (..)
   ) where
 
 import BackendName (BackendName)
-import Fmt (Buildable(build), Builder, indentF, unlinesF)
-import Servant.Client.Core
-  (ClientError(ConnectionError, DecodeFailure, FailureResponse, InvalidContentTypeHeader, UnsupportedContentType))
+import Coffer.Path (EntryPath, Path)
+import Data.Text (Text)
+import Entry (BadEntryTag, BadFieldName)
+import Fmt (Buildable(build), Builder, pretty, unlinesF, (+|), (|+))
 
-data CofferError
-  = ServantError ClientError
-  | BackendNotFound BackendName
-  | OtherError Builder
-  deriving stock (Show)
+-- | GADT for coffer internal errors.
+-- It is backend-agnostic, so it doesn't know about specific backend errors.
+data CofferError where
+  BackendError :: BackendError err => err -> CofferError
+  InternalCommandsError :: InternalCommandsError -> CofferError
+  BackendNotFound :: BackendName -> CofferError
+  BadFieldNameError :: BadFieldName -> CofferError
+  BadMasterFieldName :: Text -> BadFieldName -> CofferError
+  BadEntryTagError :: BadEntryTag -> CofferError
+
+-- | Type class for backend errors.
+class (Buildable err) => BackendError err
+
+-- | Internal errors that can be thrown if backend is in illegal state.
+data InternalCommandsError
+  = InvalidEntry Text
+  | EntryPathDoesntHavePrefix EntryPath Path
+
+instance Buildable InternalCommandsError where
+  build = \case
+    InvalidEntry entry ->
+      unlinesF @_ @Builder
+        [ "Backend returned a secret that is not a valid\
+          \ entry or directory name."
+        , "Got: '" +| entry |+ "'."
+        ]
+    EntryPathDoesntHavePrefix entryPath path ->
+      unlinesF @_ @Builder
+        [ "Expected path: '" <> pretty entryPath <> "'"
+        , "To have the prefix: '" <> pretty path <> "'"
+        ]
 
 instance Buildable CofferError where
   build = \case
-    ServantError (FailureResponse request response) ->
+    BackendError err ->
       unlinesF @_ @Builder
-        [ "Request:"
-        , indentF 2 ((build . show) request)
-        , "failed with response:"
-        , indentF 2 ((build . show) response)
+        [ "Internal backend error:"
+        , build err
         ]
-    ServantError (DecodeFailure body response) ->
+    InternalCommandsError err ->
       unlinesF @_ @Builder
-        [ "The body could not be decoded at the expected type."
-        , "Body: " <> build body
-        , "Response:"
-        , indentF 2 ((build . show) response)
+        [ "Internal error:"
+        , build err
         ]
-    ServantError (UnsupportedContentType mediatype response) ->
+    BackendNotFound backendName ->
+      "Backend with name '" <> build backendName <> "' not found."
+    BadFieldNameError err -> build err
+    BadMasterFieldName key err ->
       unlinesF @_ @Builder
-        [ "The content-type '" <> (build . show) mediatype <> "' of the response is not supported."
-        , "Response:"
-        , indentF 2 ((build . show) response)
+        [ "Attempted to create new field name from '" +| key |+ "'"
+        , ""
+        , build err
         ]
-    ServantError (InvalidContentTypeHeader response) ->
-      unlinesF @_ @Builder
-        [ "The content-type header is invalid."
-        , "Response:"
-        , indentF 2 ((build . show) response)
-        ]
-    ServantError (ConnectionError exception) ->
-      unlinesF @_ @Builder
-        [ "Connection error. No response was received."
-        , (build . show) exception
-        ]
-    BackendNotFound backendName -> "Backend with name '" <> build backendName <> "' not found."
-    OtherError t ->
-      unlinesF @_ @Builder
-        [ "An internal error occurred:"
-        , t
-        ]
+    BadEntryTagError err -> build err


### PR DESCRIPTION
## Description

## Problem 
There are 2 problems here:
- In the `Backend.Vault.Kv` module, we're constructing `OtherError` with user-facing error messages as strings.
- `CofferError` is meant to be backend-agnostic, but it assumes that all backends will (possibly) throw a `ServantError`. However, the `pass` backend, for example, does not use servant.

## Solution
1. Used ADTs + Buildable to model errors.
2. Made `CofferError` backend-agnostic.
3. Created backend-specific error type class.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

- Fixes #72.

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
