### PR TITLE
[#26] Fix `validate cabal files` CI step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
     command: nix run -f ci.nix pkgs.shellcheck -c find . -name '*.sh' -exec shellcheck {} +
 
   - label: validate cabal files
-    command: nix run -f ci.nix stack2cabal -c ./scripts/validate-cabal-files.sh
+    command: nix run -f ci.nix stack2cabal pkgs.diffutils -c ./scripts/validate-cabal-files.sh
 
   - label: stylish
     command: nix run -f ci.nix pkgs.gnumake pkgs-stylish.stylish-haskell -c ./scripts/validate-stylish.sh


### PR DESCRIPTION
## Description

Problem: The `validate cabal files` build step hasn't been working ever
since we added it. We can see this message in the logs:

```
./scripts/validate-cabal-files.sh: line 39: diff: command not found
```

The reason why the build step did not actually ever fail (thus, it was a false
negative) is because we temporarily use `set +e` to mask all non-zero
exit codes.

Solution: add the missing `diffTools` to the nix shell.

## Related issue(s)

Fixed part of #26 

## :white_check_mark: Checklist for your Pull Request


#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
