### PR TITLE
[#22] Copy with equal paths behavior fix

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -130,6 +130,7 @@ main = do
           CPRCreateErrors errors -> do
             errorMsgs <- buildErrorMessages errors
             printError $ unlinesF @_ @Builder $ "The following entries cannot be renamed:" : "" : errorMsgs
+          CPRSamePath path -> samePaths path
 
       SomeCommand cmd@(CmdCopy opts) -> do
         runCommand config cmd >>= \case
@@ -144,6 +145,7 @@ main = do
           CPRCreateErrors errors -> do
             errorMsgs <- buildErrorMessages errors
             printError $ unlinesF @_ @Builder $ "The following entries cannot be copied:" : "" : errorMsgs
+          CPRSamePath path -> samePaths path
 
       SomeCommand cmd@(CmdDelete opts) -> do
         runCommand config cmd >>= \case
@@ -187,6 +189,10 @@ main = do
 
       pathNotFound :: Member (Embed IO) r => QualifiedPath Path -> Sem r ()
       pathNotFound path = printError $ "Entry or directory not found at '" +| path |+ "'."
+
+      samePaths :: Member (Embed IO) r => QualifiedPath Path -> Sem r ()
+      samePaths path =
+        printError $ "'" +| path |+ "' and '" +| path |+ "' are the same path."
 
       createErrorToBuilder :: CreateError -> Builder
       createErrorToBuilder = \case

--- a/lib/Backend/Commands.hs
+++ b/lib/Backend/Commands.hs
@@ -314,8 +314,17 @@ buildCopyOperations
   :: forall r
    . (Members '[BackendEffect, Embed IO, Error CofferError, Error CopyResult] r)
   => SomeBackend -> SomeBackend -> QualifiedPath Path -> QualifiedPath Path -> Bool -> Sem r [CopyOperation]
-buildCopyOperations oldBackend newBackend oldQPath@(QualifiedPath oldBackendNameMb oldPath) (QualifiedPath newBackendNameMb newPath) force = do
+buildCopyOperations
+  oldBackend
+  newBackend
+  oldQPath@(QualifiedPath oldBackendNameMb oldPath)
+  newQPath@(QualifiedPath newBackendNameMb newPath)
+  force
+    = do
   entryOrDir <- getEntryOrDirThrow oldBackend CPRPathNotFound oldQPath
+
+  -- Don't need to copy directory or entry to itself
+  when (oldQPath == newQPath) $ throw (CPRSamePath oldQPath)
 
   -- Build a list of operations to perform.
   nowUtc <- embed getCurrentTime

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -73,6 +73,7 @@ data CopyResult
   = CPRSuccess [(QualifiedPath EntryPath, QualifiedPath EntryPath)]
   | CPRPathNotFound (QualifiedPath Path)
   | CPRMissingEntryName
+  | CPRSamePath (QualifiedPath Path)
   | CPRCreateErrors [(QualifiedPath EntryPath, CreateError)]
 
 data DeleteResult

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -177,7 +177,7 @@ data QualifiedPath path = QualifiedPath
   { qpBackendName :: Maybe BackendName
   , qpPath :: path
   }
-  deriving stock (Show, Functor)
+  deriving stock (Show, Eq, Functor)
 
 instance (Buildable path) => Buildable (QualifiedPath path) where
   build (QualifiedPath backendNameMb path) =

--- a/tests/golden/rename-command/rename-command.bats
+++ b/tests/golden/rename-command/rename-command.bats
@@ -156,22 +156,14 @@ EOF
 
   assert_failure
   assert_output - <<EOF
-[ERROR] The following entries cannot be renamed:
-
-'/dir/a' to '/dir/a':
-  An entry already exists at '/dir/a'.
-  Use '--force' or '-f' to overwrite existing entries.
-'/dir/b' to '/dir/b':
-  An entry already exists at '/dir/b'.
-  Use '--force' or '-f' to overwrite existing entries.
+[ERROR] '/dir' and '/dir' are the same path.
 EOF
 
   run coffer rename /dir /dir -f
 
-  assert_success
+  assert_failure
   assert_output - <<EOF
-[SUCCESS] Renamed '/dir/a' to '/dir/a'.
-[SUCCESS] Renamed '/dir/b' to '/dir/b'.
+[ERROR] '/dir' and '/dir' are the same path.
 EOF
 
   run cleanOutput coffer view /


### PR DESCRIPTION
## Description

### Problem
Currently copying entry / directory to itself is allowed in force mode.

This copying is very unnecessary, we can't see such behavior in
standard Unix `cp` command. The same applies to renaming
entries to it's current name.

### Solution
Check qualified paths for equality before copying.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #22 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
