### PR TITLE
[Chore] Fix xrefcheck's hash in sources.json

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -90,7 +90,7 @@
         "owner": "serokell",
         "repo": "xrefcheck",
         "rev": "dd0ad17f9cfed378be796fbd974aae7efb26d6b4",
-        "sha256": "1c2vlbcp82pik26y583fc5m17k3s7ir8gvvli6pri4f6njfr8x8c",
+        "sha256": "1jn6vz2ii8j24jszg9iqw0z292910g8420kp419n2wcywhiswwah",
         "type": "tarball",
         "url": "https://github.com/serokell/xrefcheck/archive/dd0ad17f9cfed378be796fbd974aae7efb26d6b4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",


### PR DESCRIPTION

## Description
Problem: For some reason, when I added `sources.json` to the project, I
used the sha256 of an older version of xrefcheck.

Solution: Use the correct hash for the version of xrefcheck we're using


## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

None

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
