### PR TITLE
[#44] Merge `--filter` and `--filter-field` options

### DIFF
--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -126,7 +126,6 @@ data FindOptions = FindOptions
   , foText :: Maybe Text
   , foSort :: Maybe (Sort, Direction)
   , foFilters :: [Filter]
-  , foFilterFields :: [(FieldName, FilterField)]
   }
   deriving stock Show
 
@@ -193,6 +192,7 @@ data FilterDate
 data Filter
   = FilterByDate FilterOp FilterDate
   | FilterByName Text
+  | FilterByField FieldName FilterField
   deriving stock Show
 
 data FilterField

--- a/tests/golden/common/common.bats
+++ b/tests/golden/common/common.bats
@@ -110,10 +110,10 @@ EOF
 }
 
 @test "bad filter field" {
-  run coffer find --filter-field "$(echo -e "name:bad\n\n~str")"
+  run coffer find --filter "$(echo -e "name:bad\n\n~str")"
 
   assert_failure
   assert_output --partial - <<EOF
-option --filter-field: Invalid filter-field format: "name:bad\n\n~str".
+option --filter: Invalid filter format: "name:bad\n\n~str".
 EOF
 }

--- a/tests/golden/find-command/find-command.bats
+++ b/tests/golden/find-command/find-command.bats
@@ -366,3 +366,32 @@ EOF
         x: y [2000-01-01 01:01:01]
 EOF
 }
+
+@test "filter field with name 'date' and 'name'" {
+  coffer create /secrets/d/ab --field date=2000 --field name=a
+  coffer create /secrets/d/ad --field date=2020 --field name=b
+  coffer create /secrets/d/abc --field date=9999
+
+  run cleanOutput coffer find / ab --filter date:contents~20 --filter "date>1000" --filter name~a
+
+  assert_success
+  assert_output - <<EOF
+/
+  secrets/
+    d/
+      ab - [2000-01-01 01:01:01]
+        name: a    [2000-01-01 01:01:01]
+        date: 2000 [2000-01-01 01:01:01]
+EOF
+
+  run cleanOutput coffer find --filter name:contents~a --filter name~a
+  assert_success
+  assert_output - <<EOF
+/
+  secrets/
+    d/
+      ab - [2000-01-01 01:01:01]
+        name: a    [2000-01-01 01:01:01]
+        date: 2000 [2000-01-01 01:01:01]
+EOF
+}

--- a/tests/golden/find-command/find-command.bats
+++ b/tests/golden/find-command/find-command.bats
@@ -189,7 +189,7 @@ EOF
   coffer create /cd --field filtering=kek
   coffer create /abcd --field filtering=kek
 
-  run cleanOutput coffer find / --filter name~ab --filter-field filtering:contents~kek
+  run cleanOutput coffer find / --filter name~ab --filter filtering:contents~kek
 
   assert_success
   assert_output - <<EOF
@@ -263,7 +263,7 @@ EOF
   coffer create /secrets/b --field filtering=cab
   coffer create /secrets/c --field filtering=zzz
 
-  run cleanOutput coffer find / --filter-field filtering:contents~bb
+  run cleanOutput coffer find / --filter filtering:contents~bb
 
   assert_success
   assert_output - <<EOF
@@ -273,7 +273,7 @@ EOF
       filtering: abbacaba [2000-01-01 01:01:01]
 EOF
 
-  run cleanOutput coffer find / --filter-field filtering:contents~ab
+  run cleanOutput coffer find / --filter filtering:contents~ab
 
   assert_success
   assert_output - <<EOF
@@ -285,7 +285,7 @@ EOF
       filtering: cab [2000-01-01 01:01:01]
 EOF
 
-  run cleanOutput coffer find / --filter-field filtering:contents~zz
+  run cleanOutput coffer find / --filter filtering:contents~zz
 
   assert_success
   assert_output - <<EOF


### PR DESCRIPTION
## Description

### Problem

@Heimdell in #44 suggested to merge --filter and --filter-field options into a single --filter option.

e.g.:
```
--filter name~vault               <- filter entries by entry name
--filter url:value~google.com     <- filter entries by field value
```

### Solution

Modified `parseFilter :: MParser Filter` supplementing it with `parseFilterByField`'s functionality.

Changed related datatypes so there is no separation between `filter` and `filter-field`.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

- Fixed part of #44:
  - [x] core has filters merged
  - [x] CLI has filters merged 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
