### PR TITLE
[#106] Backend-agnostic `listDirectoryContents`

### DIFF
--- a/lib/Backend.hs
+++ b/lib/Backend.hs
@@ -15,8 +15,7 @@ module Backend
 where
 
 import BackendName (BackendName)
-import Coffer.Path (EntryPath, Path)
-import Data.Text (Text)
+import Coffer.Path (DirectoryContents, EntryPath, Path)
 import Entry (Entry)
 import Error (CofferError)
 import Polysemy
@@ -30,7 +29,7 @@ class Show a => Backend a where
   _codec :: Toml.TomlCodec a
   _writeEntry :: Effects r => a -> Entry -> Sem r ()
   _readEntry :: Effects r => a -> EntryPath -> Sem r (Maybe Entry)
-  _listDirectoryContents :: Effects r => a -> Path -> Sem r (Maybe [Text])
+  _listDirectoryContents :: Effects r => a -> Path -> Sem r (Maybe DirectoryContents)
   _deleteEntry :: Effects r => a -> EntryPath -> Sem r ()
 
 data SomeBackend where
@@ -44,10 +43,11 @@ data BackendEffect m a where
   --   It does /not overwrite/ directories.
   --   If a directory with that path already exists, you'll end up with an entry /and/ a directory sharing the same path.
   WriteEntry :: SomeBackend -> Entry -> BackendEffect m ()
-  -- | Returns path segments: if the segment is suffixed by @/@ then that indicates a directory;
-  --   otherwise it's an entry
   ReadEntry :: SomeBackend -> EntryPath -> BackendEffect m (Maybe Entry)
-  ListDirectoryContents :: SomeBackend -> Path -> BackendEffect m (Maybe [Text])
+  -- | Returns two lists of path segments:
+  -- 1. list of path segments that represent directories
+  -- 2. list of path segments that represent entries
+  ListDirectoryContents :: SomeBackend -> Path -> BackendEffect m (Maybe DirectoryContents)
   -- | Once all entries are deleted from a directory, then the directory disappears
   --   (i.e. @ListDirectoryContents@ will no longer list that directory)
   DeleteEntry :: SomeBackend -> EntryPath -> BackendEffect m ()

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -7,6 +7,9 @@ module Coffer.Path
   , unPathSegment
   , mkPathSegment
   , pathSegmentAllowedCharacters
+  , DirectoryContents(..)
+  , directoryNames
+  , entryNames
   , HasPathSegments(..)
   , Path(..)
   , mkPath
@@ -51,6 +54,13 @@ newtype PathSegment = UnsafeMkPathSegment { unPathSegment :: Text }
   deriving stock (Show, Eq, Generic)
   deriving newtype (Buildable, ToHttpApiData, FromHttpApiData)
   deriving newtype (Hashable, A.FromJSON, A.ToJSON, A.FromJSONKey, A.ToJSONKey)
+
+data DirectoryContents = DirectoryContents
+  { dcDirectoryNames :: [PathSegment]
+  , dcEntryNames :: [PathSegment]
+  }
+  deriving stock (Show)
+makeLensesWith abbreviatedFields ''DirectoryContents
 
 mkPathSegment :: Text -> Either Text PathSegment
 mkPathSegment segment

--- a/lib/Error.hs
+++ b/lib/Error.hs
@@ -30,17 +30,10 @@ class (Buildable err) => BackendError err
 
 -- | Internal errors that can be thrown if backend is in illegal state.
 data InternalCommandsError
-  = InvalidEntry Text
-  | EntryPathDoesntHavePrefix EntryPath Path
+  = EntryPathDoesntHavePrefix EntryPath Path
 
 instance Buildable InternalCommandsError where
   build = \case
-    InvalidEntry pathSegment ->
-      [int|s|
-        Backend returned a path segment that is not a valid \
-        entry or directory name.
-        Got: '#{pathSegment}'.
-      |]
     EntryPathDoesntHavePrefix entryPath path ->
       [int|s|
         Expected path: '#{entryPath}'


### PR DESCRIPTION
## Description

## Problem 
At this moment the `listDirectoryContents` function returns `[Text]`
and in `getEntryOrDir` we rely on the fact that `vault` adds a '/'
to the directory. But other backends might not behave like this.

## Solution 
Created new data `DirectoryContents` which stores 2 lists:
1. list with directories
2. list with entries
and changed return type from `Maybe [Text]` to `Maybe DirectoryContents`
in `listDirectoryContents` function.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

- Fixes #106 

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
