### PR TITLE
[#98] One style errors

### DIFF
--- a/tests/golden/find-command/find-command.bats
+++ b/tests/golden/find-command/find-command.bats
@@ -131,6 +131,54 @@ EOF
     a - [2000-01-01 01:01:01]
       sortfield: c [2000-01-01 01:01:01]
 EOF
+
+
+}
+
+@test "sort on field with name 'date' and 'name'" {
+
+  coffer create /secrets/a
+  coffer create /secrets/c
+  coffer create /secrets/b
+
+  coffer set-field /secrets/a name name1
+  coffer set-field /secrets/c name name2
+  coffer set-field /secrets/b name name3
+
+  run cleanOutput coffer find / --sort name:contents:desc
+
+  assert_success
+  assert_output - <<EOF
+/
+  secrets/
+    b - [2000-01-01 01:01:01]
+      name: name3 [2000-01-01 01:01:01]
+    c - [2000-01-01 01:01:01]
+      name: name2 [2000-01-01 01:01:01]
+    a - [2000-01-01 01:01:01]
+      name: name1 [2000-01-01 01:01:01]
+EOF
+
+  coffer set-field /secrets/a date date1
+  coffer set-field /secrets/c date date2
+  coffer set-field /secrets/b date date3
+
+  run cleanOutput coffer find / --sort date:contents:desc
+
+  assert_success
+  assert_output - <<EOF
+/
+  secrets/
+    b - [2000-01-01 01:01:01]
+      name: name3 [2000-01-01 01:01:01]
+      date: date3 [2000-01-01 01:01:01]
+    c - [2000-01-01 01:01:01]
+      name: name2 [2000-01-01 01:01:01]
+      date: date2 [2000-01-01 01:01:01]
+    a - [2000-01-01 01:01:01]
+      name: name1 [2000-01-01 01:01:01]
+      date: date1 [2000-01-01 01:01:01]
+EOF
 }
 
 @test "filter entries names" {


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

Problem : Parse error messages in `find --sort` and `find --find` had different styles

Solution : rewrote `sort` parsing to Megaparsec instead of `splitOn(":")`

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #98 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
