### PR TITLE
[#82] Pretty `ToJSON` instances

### DIFF
--- a/coffer.cabal
+++ b/coffer.cabal
@@ -396,7 +396,6 @@ test-suite server-integration
     , coffer
     , extra
     , lens
-    , lens-aeson
     , process
     , req
     , syb

--- a/coffer.cabal
+++ b/coffer.cabal
@@ -99,6 +99,7 @@ library
   build-depends:
       aeson
     , aeson-casing
+    , aeson-qq
     , ansi-terminal
     , base >=4.14.3.0 && <5
     , bytestring

--- a/lib/BackendName.hs
+++ b/lib/BackendName.hs
@@ -11,7 +11,6 @@ module BackendName
   ) where
 
 import Coffer.Util (didimatch)
-import Data.Aeson qualified as A
 import Data.Hashable (Hashable)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -20,7 +19,7 @@ import Toml qualified
 
 newtype BackendName = UnsafeBackendName Text
   deriving stock (Show, Eq)
-  deriving newtype (A.ToJSON, A.ToJSONKey, A.FromJSON, A.FromJSONKey, Hashable, Buildable)
+  deriving newtype (Hashable, Buildable)
 
 backendNameCharSet :: [Char]
 backendNameCharSet = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ "-_;"

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -5,11 +5,14 @@
 module CLI.Types where
 
 import Coffer.Directory (Directory)
-import Coffer.Path (EntryPath, Path, QualifiedPath)
+import Coffer.Path (EntryPath, Path, QualifiedPath(qpPath))
 import Coffer.Util (MParser)
 import Control.Applicative (Alternative(some), optional)
+import Control.Lens hiding (noneOf)
 import Control.Monad (guard, void)
 import Data.Aeson hiding ((<?>))
+import Data.Aeson.QQ (aesonQQ)
+import Data.Aeson.Types (emptyObject)
 import Data.Bifunctor (first)
 import Data.Char qualified as Char
 import Data.Fixed (Pico)
@@ -64,35 +67,31 @@ data ViewResult
   | VRPathNotFound (QualifiedPath Path)
   | VRDirectoryNoFieldMatch (QualifiedPath Path) FieldName
   | VREntryNoFieldMatch (QualifiedPath EntryPath) FieldName
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data CreateError
   = CEParentDirectoryIsEntry (QualifiedPath EntryPath, QualifiedPath EntryPath)
   | CEDestinationIsDirectory (QualifiedPath EntryPath)
   | CEEntryAlreadyExists (QualifiedPath EntryPath)
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (ToJSON)
 
 data CreateResult
   = CRSuccess (QualifiedPath EntryPath)
   | CRCreateError CreateError
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data SetFieldResult
   = SFRSuccess FieldName (QualifiedPath Entry)
   | SFREntryNotFound (QualifiedPath EntryPath)
   | SFRMissingFieldContents FieldName (QualifiedPath EntryPath)
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data DeleteFieldResult
   = DFRSuccess FieldName (QualifiedPath EntryPath)
   | DFREntryNotFound (QualifiedPath EntryPath)
   | DFRFieldNotFound FieldName
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 type RenameResult = CopyResult
 
@@ -102,23 +101,20 @@ data CopyResult
   | CPRMissingEntryName
   | CPRSamePath (QualifiedPath Path)
   | CPRCreateErrors [(QualifiedPath EntryPath, CreateError)]
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data DeleteResult
   = DRSuccess Bool [QualifiedPath EntryPath]
   | DRPathNotFound (QualifiedPath Path)
   | DRDirectoryFound (QualifiedPath Path)
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data TagResult
   = TRSuccess (QualifiedPath EntryPath) EntryTag Bool
   | TREntryNotFound (QualifiedPath EntryPath)
   | TRTagNotFound EntryTag
   | TRDuplicateTag EntryTag
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 ----------------------------------------------------------------------------
 -- Options
@@ -129,7 +125,7 @@ data ViewOptions = ViewOptions
   , voFieldName :: Maybe FieldName
   }
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (ToJSON)
 
 data CreateOptions = CreateOptions
   { coQPath :: QualifiedPath EntryPath
@@ -140,7 +136,7 @@ data CreateOptions = CreateOptions
   , coPrivateFields :: [FieldInfo]
   }
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (ToJSON)
 
 data SetFieldOptions = SetFieldOptions
   { sfoQPath :: QualifiedPath EntryPath
@@ -149,14 +145,14 @@ data SetFieldOptions = SetFieldOptions
   , sfoVisibility :: Maybe FieldVisibility
   }
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (ToJSON)
 
 data DeleteFieldOptions = DeleteFieldOptions
   { dfoQPath :: QualifiedPath EntryPath
   , dfoFieldName :: FieldName
   }
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (ToJSON)
 
 data FindOptions = FindOptions
   { foQPath :: Maybe (QualifiedPath Path)
@@ -165,7 +161,7 @@ data FindOptions = FindOptions
   , foFilters :: [Filter]
   }
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (ToJSON)
 
 data RenameOptions = RenameOptions
   { roDryRun :: Bool
@@ -174,7 +170,7 @@ data RenameOptions = RenameOptions
   , roForce :: Bool
   }
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (ToJSON)
 
 data CopyOptions = CopyOptions
   { cpoDryRun :: Bool
@@ -183,7 +179,7 @@ data CopyOptions = CopyOptions
   , cpoForce :: Bool
   }
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (ToJSON)
 
 data DeleteOptions = DeleteOptions
   { doDryRun :: Bool
@@ -191,7 +187,7 @@ data DeleteOptions = DeleteOptions
   , doRecursive :: Bool
   }
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (ToJSON)
 
 data TagOptions = TagOptions
   { toQPath :: QualifiedPath EntryPath
@@ -199,7 +195,7 @@ data TagOptions = TagOptions
   , toDelete :: Bool
   }
   deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (ToJSON)
 
 ----------------------------------------------------------------------------
 -- Option arguments
@@ -326,6 +322,88 @@ instance FromHttpApiData (FieldName, FilterField) where
               date <- parseFilterDate
               return (field, FilterFieldByDate op date)
           ]
+
+-- These @ToJSON@ instances are for success results only.
+
+instance ToJSON ViewResult where
+  toJSON = \case
+    VRDirectory dir -> toJSON dir
+    VREntry entry -> toJSON entry
+    VRField fieldName field ->
+      [aesonQQ|
+        {
+          "fieldName": #{fieldName},
+          "field": #{field}
+        }
+      |]
+    _ -> emptyObject
+
+instance ToJSON CreateResult where
+  toJSON = \case
+    CRSuccess entryPath ->
+      [aesonQQ|
+        {
+          "path": #{entryPath}
+        }
+      |]
+    _ -> emptyObject
+
+instance ToJSON SetFieldResult where
+  toJSON = \case
+    SFRSuccess _ qualifiedEntry -> do
+      let entry = qpPath qualifiedEntry
+      [aesonQQ|
+        {
+          "entry": #{entry}
+        }
+      |]
+    _ -> emptyObject
+
+instance ToJSON DeleteFieldResult where
+  toJSON = \case
+    DFRSuccess fieldName entryPath ->
+      [aesonQQ|
+        {
+          "fieldName": #{fieldName},
+          "path": #{entryPath}
+        }
+      |]
+    _ -> emptyObject
+
+instance ToJSON CopyResult where
+  toJSON = \case
+    CPRSuccess dryRun fromTo -> do
+      let copyResults =
+            fromTo <&> \(from, to) -> [aesonQQ| { "from": #{from}, "to": #{to} } |]
+      [aesonQQ|
+        {
+          "dryRun": #{dryRun},
+          "copyResults": #{copyResults}
+        }
+      |]
+    _ -> emptyObject
+
+instance ToJSON DeleteResult where
+  toJSON = \case
+    DRSuccess dryRun deleted ->
+      [aesonQQ|
+        {
+          "dryRun": #{dryRun},
+          "deleteResults": #{deleted}
+        }
+      |]
+    _ -> emptyObject
+
+instance ToJSON TagResult where
+  toJSON = \case
+    TRSuccess entryPath tag delete ->
+      [aesonQQ|
+        {
+          "entryPath": #{entryPath},
+          "tag": #{tag}, "delete": #{delete}
+        }
+      |]
+    _ -> emptyObject
 
 ----------------------------------------------------------------------------
 -- Utils

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -124,8 +124,7 @@ data ViewOptions = ViewOptions
   { voQPath :: QualifiedPath Path
   , voFieldName :: Maybe FieldName
   }
-  deriving stock (Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving stock (Show)
 
 data CreateOptions = CreateOptions
   { coQPath :: QualifiedPath EntryPath
@@ -135,8 +134,7 @@ data CreateOptions = CreateOptions
   , coFields :: [FieldInfo]
   , coPrivateFields :: [FieldInfo]
   }
-  deriving stock (Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving stock (Show)
 
 data SetFieldOptions = SetFieldOptions
   { sfoQPath :: QualifiedPath EntryPath
@@ -144,15 +142,13 @@ data SetFieldOptions = SetFieldOptions
   , sfoFieldContents :: Maybe FieldContents
   , sfoVisibility :: Maybe FieldVisibility
   }
-  deriving stock (Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving stock (Show)
 
 data DeleteFieldOptions = DeleteFieldOptions
   { dfoQPath :: QualifiedPath EntryPath
   , dfoFieldName :: FieldName
   }
-  deriving stock (Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving stock (Show)
 
 data FindOptions = FindOptions
   { foQPath :: Maybe (QualifiedPath Path)
@@ -160,8 +156,7 @@ data FindOptions = FindOptions
   , foSort :: Maybe (Sort, Direction)
   , foFilters :: [Filter]
   }
-  deriving stock (Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving stock (Show)
 
 data RenameOptions = RenameOptions
   { roDryRun :: Bool
@@ -169,8 +164,7 @@ data RenameOptions = RenameOptions
   , roQNewPath :: QualifiedPath Path
   , roForce :: Bool
   }
-  deriving stock (Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving stock (Show)
 
 data CopyOptions = CopyOptions
   { cpoDryRun :: Bool
@@ -178,24 +172,21 @@ data CopyOptions = CopyOptions
   , cpoQNewPath :: QualifiedPath Path
   , cpoForce :: Bool
   }
-  deriving stock (Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving stock (Show)
 
 data DeleteOptions = DeleteOptions
   { doDryRun :: Bool
   , doQPath :: QualifiedPath Path
   , doRecursive :: Bool
   }
-  deriving stock (Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving stock (Show)
 
 data TagOptions = TagOptions
   { toQPath :: QualifiedPath EntryPath
   , toTagName :: EntryTag
   , toDelete :: Bool
   }
-  deriving stock (Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving stock (Show)
 
 ----------------------------------------------------------------------------
 -- Option arguments
@@ -205,45 +196,38 @@ data FieldInfo = FieldInfo
   { fiName :: FieldName
   , fiContents :: FieldContents
   }
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data Direction = Asc | Desc
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data Sort
   = SortByEntryName
   | SortByEntryDate
   | SortByFieldContents FieldName
   | SortByFieldDate FieldName
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data FilterOp = OpGT | OpGTE | OpLT | OpLTE | OpEQ
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data FilterDate
   = FDYear Year
   | FDMonth Month
   | FDDay Day
   | FDTime UTCTime
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data Filter
   = FilterByDate FilterOp FilterDate
   | FilterByName Text
   | FilterByField FieldName FilterField
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 data FilterField
   = FilterFieldByDate FilterOp FilterDate
   | FilterFieldByContents Text
-  deriving stock (Show, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show)
 
 ----------------------------------------------------------------------------
 -- Instances

--- a/lib/Coffer/Directory.hs
+++ b/lib/Coffer/Directory.hs
@@ -19,7 +19,8 @@ module Coffer.Directory
 
 import Coffer.Path (PathSegment, entryPathParentDir, pathSegments)
 import Control.Lens
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson.Casing
+import Data.Aeson.TH
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HashMap
 import Data.Maybe qualified as Maybe
@@ -36,7 +37,7 @@ data Directory = Directory
   , dSubdirs :: HashMap PathSegment Directory
   }
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+deriveToJSON (aesonPrefix camelCase) ''Directory
 
 makeLensesWith abbreviatedFields 'Directory
 

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -28,7 +28,7 @@ module Coffer.Path
 import BackendName (BackendName, newBackendName)
 import Control.Lens
 import Control.Monad ((>=>))
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (ToJSON, Value(String))
 import Data.Aeson qualified as A
 import Data.Hashable (Hashable)
 import Data.List qualified as List
@@ -123,7 +123,10 @@ mkPath path = do
 -- | An entry's full path (directory + entry's name).
 newtype EntryPath = EntryPath { unEntryPath :: NonEmpty PathSegment }
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (Hashable, A.FromJSON, A.ToJSON, A.FromJSONKey, A.ToJSONKey)
+  deriving anyclass (Hashable)
+
+instance A.ToJSON EntryPath where
+  toJSON = String . pretty
 
 instance ToHttpApiData EntryPath where
   toUrlPiece = fmt . build
@@ -206,8 +209,10 @@ data QualifiedPath path = QualifiedPath
   { qpBackendName :: Maybe BackendName
   , qpPath :: path
   }
-  deriving stock (Show, Eq, Functor, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving stock (Show, Eq, Functor)
+
+instance (Buildable path) => ToJSON (QualifiedPath path) where
+  toJSON = String . pretty
 
 instance (Buildable path) => Buildable (QualifiedPath path) where
   build (QualifiedPath backendNameMb path) =

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -53,7 +53,7 @@ import Servant (FromHttpApiData(..), ToHttpApiData(..))
 newtype PathSegment = UnsafeMkPathSegment { unPathSegment :: Text }
   deriving stock (Show, Eq, Generic)
   deriving newtype (Buildable, ToHttpApiData, FromHttpApiData)
-  deriving newtype (Hashable, A.FromJSON, A.ToJSON, A.FromJSONKey, A.ToJSONKey)
+  deriving newtype (Hashable, A.ToJSON, A.ToJSONKey)
 
 data DirectoryContents = DirectoryContents
   { dcDirectoryNames :: [PathSegment]
@@ -77,7 +77,7 @@ pathSegmentAllowedCharacters = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ "-_"
 newtype Path = Path { unPath :: [PathSegment] }
   deriving stock (Show, Eq, Generic)
   deriving newtype (Semigroup, Monoid)
-  deriving newtype (Hashable, A.FromJSON, A.ToJSON, A.FromJSONKey, A.ToJSONKey)
+  deriving newtype (Hashable, A.ToJSON, A.ToJSONKey)
 
 instance ToHttpApiData Path where
   toUrlPiece = fmt . build

--- a/lib/Entry.hs
+++ b/lib/Entry.hs
@@ -33,6 +33,8 @@ where
 import Coffer.Path (EntryPath)
 import Control.Lens
 import Data.Aeson qualified as A
+import Data.Aeson.Casing
+import Data.Aeson.TH
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HS
 import Data.Hashable (Hashable)
@@ -129,7 +131,8 @@ data Field =
   , fContents :: FieldContents
   }
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (Hashable, A.FromJSON, A.ToJSON, A.FromJSONKey, A.ToJSONKey)
+  deriving anyclass (Hashable)
+deriveToJSON (aesonPrefix camelCase) ''Field
 makeLensesWith abbreviatedFields ''Field
 
 newField :: UTCTime -> FieldContents -> Field
@@ -149,7 +152,8 @@ data Entry =
   , eTags :: Set EntryTag
   }
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (Hashable, A.FromJSON, A.ToJSON, A.FromJSONKey, A.ToJSONKey)
+  deriving anyclass (Hashable)
+deriveToJSON (aesonPrefix camelCase) ''Entry
 makeLensesWith abbreviatedFields ''Entry
 
 newEntry :: EntryPath -> UTCTime -> Entry

--- a/package.yaml
+++ b/package.yaml
@@ -89,6 +89,7 @@ library:
   dependencies:
     - aeson
     - aeson-casing
+    - aeson-qq
     - ansi-terminal
     - bytestring
     - containers

--- a/package.yaml
+++ b/package.yaml
@@ -173,7 +173,6 @@ tests:
       - coffer
       - extra
       - lens
-      - lens-aeson
       - process
       - req
       - syb

--- a/tests/server-integration/Utils.hs
+++ b/tests/server-integration/Utils.hs
@@ -4,7 +4,6 @@
 
 module Utils
   ( scrubDates
-  , getValueContents
   , cofferTest
   , runVault
   , baseUrl
@@ -15,7 +14,6 @@ import Control.Exception (try)
 import Control.Lens
 import Control.Monad (void)
 import Data.Aeson (Object, Value)
-import Data.Aeson.Lens
 import Data.Aeson.QQ.Simple (aesonQQ)
 import Data.Generics
 import Data.Text (Text)
@@ -23,7 +21,6 @@ import GHC.IO.Handle (Handle)
 import Network.HTTP.Req
 import System.Process
   (CreateProcess(std_err, std_out), ProcessHandle, StdStream(NoStream), createProcess, proc)
-import Test.Tasty.HUnit (assertFailure)
 
 procWithoutOutput :: CreateProcess -> CreateProcess
 procWithoutOutput cp = cp
@@ -65,14 +62,7 @@ scrubDates :: Value -> Value
 scrubDates =
   everywhere $ mkT @_ @Object \val ->
     val
-      & ix "eDateModified" .~ ""
-      & ix "fDateModified" .~ ""
-
-getValueContents :: Value -> IO Value
-getValueContents value = do
-  case value ^? key "contents" of
-    Just res -> pure res
-    Nothing -> assertFailure $ "Expected field \"contents\", but don't get it: " <> show value
+      & ix "dateModified" .~ ""
 
 -- | This function setups @vault@ for test.
 cofferTest :: IO () -> IO ()


### PR DESCRIPTION
## Description

## Problem 
At this moment `ToJSON` instances leak a lot of internal info.
Some of them look very ugly (e.g. `EntryPath`).

## Solution 
Used `deriveToJSON (aesonPrefix camelCase)` to derive some instances.
`QualifiedPath` `ToJSON` instance is handcrafted. Also removed unnecessary
`FromJSON` instances.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

- Fixes #82 

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
