### PR TITLE
[#111] Correct endpoints results in Web API

### DIFF
--- a/coffer.cabal
+++ b/coffer.cabal
@@ -99,7 +99,6 @@ library
   build-depends:
       aeson
     , aeson-casing
-    , aeson-qq
     , ansi-terminal
     , base >=4.14.3.0 && <5
     , bytestring

--- a/lib/Coffer/PrettyPrint.hs
+++ b/lib/Coffer/PrettyPrint.hs
@@ -11,6 +11,7 @@ import Coffer.Path (EntryPath, Path, QualifiedPath(qpPath))
 import Control.Lens
 import Data.Text (Text)
 import Data.Text qualified as T
+import Entry (path)
 import Entry qualified as E
 import Fmt (Buildable(build), Builder, fmt, indentF, pretty, unlinesF)
 import Text.Interpolation.Nyan
@@ -59,7 +60,7 @@ buildCreateError mode = \case
 
 buildCreateResult :: PrettyPrintMode -> CreateResult -> Builder
 buildCreateResult mode = \case
-  CRSuccess path -> [int|s|Entry created at '#{path}'.|]
+  CRSuccess entry -> [int|s|Entry created at '#{view path <$> entry}'.|]
   CRCreateError error -> [int|s|
       The entry cannot be created:
 
@@ -94,8 +95,8 @@ buildDeleteFieldResult _ = \case
   DFRFieldNotFound fieldName -> [int|s|
       Entry does not have a field with name '#{fieldName}'.
     |]
-  DFRSuccess fieldName path -> [int|s|
-      Deleted field '#{fieldName}' from '#{path}'.
+  DFRSuccess fieldName entry -> [int|s|
+      Deleted field '#{fieldName}' from '#{view path <$> entry}'.
     |]
 
 getEntryFromCreateError :: CreateError -> QualifiedPath EntryPath
@@ -166,10 +167,10 @@ buildDeleteResult mode = \case
 buildTagResult :: PrettyPrintMode -> TagResult -> Builder
 buildTagResult _ = \case
   TREntryNotFound path -> buildEntryNotFound path
-  TRSuccess path tagName delete ->
+  TRSuccess entry tagName delete ->
     if delete
-      then [int|s|Removed tag '#{tagName}' from '#{path}'.|]
-      else [int|s|Added tag '#{tagName}' to '#{path}'.|]
+      then [int|s|Removed tag '#{tagName}' from '#{view path <$> entry}'.|]
+      else [int|s|Added tag '#{tagName}' to '#{view path <$> entry}'.|]
   TRTagNotFound tag ->
     [int|s|Entry does not have the tag '#{tag}'.|]
   TRDuplicateTag tag ->

--- a/lib/Web/API.hs
+++ b/lib/Web/API.hs
@@ -19,29 +19,28 @@ type API
   :> "api" :> "v1" :> "content" :>
     ( "view"
       :> RequiredParam "path"  (QualifiedPath Path)
-      :> OptionalParam "field" FieldName
-      :> Get '[JSON] ViewResult
+      :> Get '[JSON] Directory
 
     :<|> "create"
       :> RequiredParam "path" (QualifiedPath EntryPath)
       :> QueryFlag     "force"
       :> ReqBody '[JSON] NewEntry
-      :> Post '[JSON] CreateResult
+      :> Post '[JSON] Entry
 
     :<|> "set-field"
       :> RequiredParam "path" (QualifiedPath EntryPath)
       :> RequiredParam "field" FieldName
       :>
-        (    "private" :> Post '[JSON] SetFieldResult
-        :<|> "public"  :> Post '[JSON] SetFieldResult
+        (    "private" :> Post '[JSON] Entry
+        :<|> "public"  :> Post '[JSON] Entry
         :<|> ReqBody '[JSON] (Maybe FieldContents)
-          :> Post '[JSON] SetFieldResult
+          :> Post '[JSON] Entry
         )
 
     :<|> "delete-field"
       :> RequiredParam "path" (QualifiedPath EntryPath)
       :> RequiredParam "field" FieldName
-      :> Delete '[JSON] DeleteFieldResult
+      :> Delete '[JSON] Entry
 
     :<|> "find"
       :> OptionalParam  "path" (QualifiedPath Path)
@@ -55,27 +54,27 @@ type API
       :> RequiredParam "old-path" (QualifiedPath Path)
       :> RequiredParam "new-path" (QualifiedPath Path)
       :> QueryFlag     "force"
-      :> Post '[JSON] RenameResult
+      :> Post '[JSON] [(EntryPath, EntryPath)]
 
     :<|> "copy"
       :> QueryFlag     "dry-run"
       :> RequiredParam "old-path" (QualifiedPath Path)
       :> RequiredParam "new-path" (QualifiedPath Path)
       :> QueryFlag     "force"
-      :> Post '[JSON] CopyResult
+      :> Post '[JSON] [(EntryPath, EntryPath)]
 
     :<|> "delete"
       :> QueryFlag     "dry-run"
       :> RequiredParam "path" (QualifiedPath Path)
       :> QueryFlag     "recursive"
-      :> Delete '[JSON] DeleteResult
+      :> DeleteNoContent
 
     :<|> "tag"
       :> RequiredParam "path" (QualifiedPath EntryPath)
       :> RequiredParam "tag" EntryTag
       :>
-        (    Post   '[JSON] TagResult
-        :<|> Delete '[JSON] TagResult
+        (    Post   '[JSON] Entry
+        :<|> Delete '[JSON] Entry
         )
     )
 

--- a/package.yaml
+++ b/package.yaml
@@ -89,7 +89,6 @@ library:
   dependencies:
     - aeson
     - aeson-casing
-    - aeson-qq
     - ansi-terminal
     - bytestring
     - containers

--- a/tests/server-integration/Integration.hs
+++ b/tests/server-integration/Integration.hs
@@ -28,7 +28,32 @@ unit_create_an_entry = cofferTest do
             ]
         )
 
-  responseBody response @?= [aesonQQ| { "path": "/entry" } |]
+  scrubDates (responseBody response) @?= expected
+  where
+    expected =
+      [aesonQQ|
+        {
+          "path": "/entry",
+          "dateModified": "",
+          "masterField": null,
+          "fields": {
+              "public-field": {
+                  "dateModified": "",
+                  "visibility": "public",
+                  "contents": "field1"
+              },
+              "private-field": {
+                  "dateModified": "",
+                  "visibility": "private",
+                  "contents": "multiline\nfield"
+              }
+          },
+          "tags": [
+              "first-tag",
+              "second-tag"
+          ]
+        }
+      |]
 
 unit_view_an_entry :: IO ()
 unit_view_an_entry = cofferTest do
@@ -63,24 +88,29 @@ unit_view_an_entry = cofferTest do
     expected =
       [aesonQQ|
         {
-          "tags": [
-              "first-tag",
-              "second-tag"
-          ],
-          "masterField": null,
-          "path": "/entry",
-          "fields": {
-              "public-field": {
-                  "contents": "field1",
-                  "visibility": "public",
-                  "dateModified": ""
-              },
-              "private-field": {
-                  "contents": "multiline\nfield",
-                  "visibility": "private",
-                  "dateModified": ""
+          "entries": [
+              {
+                "path": "/entry",
+                "dateModified": "",
+                "masterField": null,
+                "fields": {
+                    "public-field": {
+                        "dateModified": "",
+                        "visibility": "public",
+                        "contents": "field1"
+                    },
+                    "private-field": {
+                        "dateModified": "",
+                        "visibility": "private",
+                        "contents": "multiline\nfield"
+                    }
+                },
+                "tags": [
+                    "first-tag",
+                    "second-tag"
+                ]
               }
-          },
-          "dateModified": ""
+          ],
+          "subdirs": {}
         }
       |]


### PR DESCRIPTION
## Description

## Problem 
At this moment in Web API in all endpoints (except for `find`)
we return the corresponding result from `CLI.Types`.

But it seems not correct, because these results contain
both success and errors. And API should return only success results
(error results return in corresponding handlers).

## Solution 
Changed endpoints results to `Entry | Directory`. Some changes
demanded changes in `CLI.Types` (e.g. returning `Entry` instead of `EntryPath`).


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

- Fixes #111 

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
