### PR TITLE
[#89] Reuse existing megaparsec parsers

### DIFF
--- a/lib/CLI/Parser.hs
+++ b/lib/CLI/Parser.hs
@@ -484,7 +484,7 @@ expectedFilterFormat = Pretty.vsep
 
 parseFilterOp :: MParser FilterOp
 parseFilterOp =
-  asum @[]
+  P.choice @[]
     [ P.string ">=" $> OpGTE
     , P.string "<=" $> OpLTE
     , P.char '>' $> OpGT

--- a/lib/CLI/Parser.hs
+++ b/lib/CLI/Parser.hs
@@ -12,11 +12,9 @@ module CLI.Parser
 import BackendName (BackendName, newBackendName)
 import CLI.Types
 import Coffer.Path (EntryPath, Path, QualifiedPath(QualifiedPath), mkEntryPath, mkPath)
-import Coffer.Util (MParser)
-import Control.Monad (void)
 import Data.Bifunctor (first)
 import Data.Function ((&))
-import Data.Functor (($>), (<&>))
+import Data.Functor ((<&>))
 import Data.List qualified as List
 import Data.Map (Map)
 import Data.Map qualified as M
@@ -28,9 +26,7 @@ import Fmt (pretty)
 import Options.Applicative
 import Options.Applicative.Help.Pretty qualified as Pretty
 import Text.Interpolation.Nyan
-import Text.Megaparsec (try)
 import Text.Megaparsec qualified as P
-import Text.Megaparsec.Char qualified as P
 
 {-# ANN module ("HLint: ignore Use <$>" :: Text) #-}
 
@@ -460,42 +456,6 @@ expectedFilterFormat = Pretty.vsep
   , "<op> can be '<=', '>=', '<', '>', or '='."
   , "<date> can be 'YYYY', 'YYYY-MM', 'YYYY-MM-DD', or 'YYYY-MM-DD HH:MM:SS'."
   , "Examples: 'name~vault', 'date<2020-02', 'url:contents~google.com', 'pw:date<2020-02'."
-  ]
-
-----------------------------------------------------------------------------
--- Megaparsec
-----------------------------------------------------------------------------
-
-parseSort :: MParser (Sort, Direction)
-parseSort = do
-  sort <- parseSortMeans
-  void $ P.char ':'
-  direction <- parseSortDirection
-  return (sort, direction)
-
-parseSortDirection :: MParser Direction
-parseSortDirection =
-      P.string "asc" $> Asc
-  <|> P.string "desc" $> Desc
-
-parseSortMeans :: MParser Sort
-parseSortMeans =
-  try parseSortMeansByFieldContentsOrDate
-  <|> parseSortMeansByNameOrDate
-
-parseSortMeansByFieldContentsOrDate :: MParser Sort
-parseSortMeansByFieldContentsOrDate = do
-  fieldName <- parseFieldNameWhile (/= ':')
-  void $ P.char ':'
-  P.choice @[] $
-    [ (SortByFieldDate fieldName)     <$ (P.string "date")
-    , (SortByFieldContents fieldName) <$ (P.string "contents")
-    ]
-
-parseSortMeansByNameOrDate :: MParser Sort
-parseSortMeansByNameOrDate = P.choice @[] $
-  [ SortByEntryName <$ P.string "name"
-  , SortByEntryDate <$ (P.string "date")
   ]
 
 ----------------------------------------------------------------------------

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -232,27 +232,8 @@ data FilterField
 -- Instances
 ----------------------------------------------------------------------------
 
--- TODO: don't forget to parse @FilterByField@.
--- Probably would be resolved after fixing (https://github.com/serokell/coffer/issues/89)
 instance FromHttpApiData Filter where
-  parseUrlPiece = toServantParser do
-    choice
-      [ do
-          void "name~"
-          name <- takeRest
-          guard $ not $ T.null name
-          return $ FilterByName name
-      , do
-          void "date"
-          op <- choice
-            [ ">=" $> OpGTE
-            , "<=" $> OpLTE
-            , ">"  $> OpGT
-            , "<"  $> OpLT
-            , "="  $> OpEQ
-            ]
-          FilterByDate op <$> parseFilterDate
-      ]
+  parseUrlPiece = toServantParser parseFilter
 
 instance FromHttpApiData (Sort, Direction) where
   parseUrlPiece = toServantParser do

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -261,33 +261,6 @@ instance FromHttpApiData (Sort, Direction) where
               return (means, direction)
       ]
 
-instance FromHttpApiData (FieldName, FilterField) where
-  parseUrlPiece = toServantParser do
-    field <- fieldName
-    void ":"
-    case newFieldName field of
-      Left _ -> fail "field name is incorrect"
-      Right field -> do
-        choice
-          [ do
-              void "value~"
-              value <- takeRest
-              guard $ not $ T.null value
-              return (field, FilterFieldByContents value)
-          , do
-              void "date"
-              op <- choice
-                [ ">=" $> OpGTE
-                , "<=" $> OpLTE
-                , ">"  $> OpGT
-                , "<"  $> OpLT
-                , "="  $> OpEQ
-                ]
-              date <- parseFilterDate
-              return (field, FilterFieldByDate op date)
-          ]
-
-
 ----------------------------------------------------------------------------
 -- Megaparsec
 ----------------------------------------------------------------------------

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -234,30 +234,7 @@ instance FromHttpApiData Filter where
   parseUrlPiece = toServantParser parseFilter
 
 instance FromHttpApiData (Sort, Direction) where
-  parseUrlPiece = toServantParser do
-    P.choice
-      [ P.try do
-          means <- P.choice [SortByEntryName <$ "name", SortByEntryDate <$ "date"]
-          void ":"
-          direction <- P.choice [Asc <$ "asc", Desc <$ "desc"]
-          P.eof
-          return (means, direction)
-
-      , do
-          (field, _) <- P.match $ some $ P.noneOf [':']
-          case newFieldName field of
-            Left _ -> fail "field name is incorrect"
-            Right field -> do
-              void ":"
-              means <- P.choice
-                [ SortByFieldContents field <$ "contents"
-                , SortByFieldDate  field <$ "date"
-                ]
-              void ":"
-              direction <- P.choice [Asc <$ "asc", Desc <$ "desc"]
-              P.eof
-              return (means, direction)
-      ]
+  parseUrlPiece = toServantParser parseSort
 
 ----------------------------------------------------------------------------
 -- Megaparsec

--- a/lib/CLI/Types.hs
+++ b/lib/CLI/Types.hs
@@ -252,7 +252,7 @@ instance FromHttpApiData (Sort, Direction) where
             Right field -> do
               void ":"
               means <- choice
-                [ SortByFieldContents field <$ "value"
+                [ SortByFieldContents field <$ "contents"
                 , SortByFieldDate  field <$ "date"
                 ]
               void ":"

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -15,6 +15,7 @@ module Coffer.Path
   , mkPath
   , EntryPath(..)
   , mkEntryPath
+  , mkQualifiedPath
   , entryPathName
   , entryPathParentDir
   , entryPathParentDirs
@@ -30,6 +31,7 @@ import Control.Lens
 import Control.Monad ((>=>))
 import Data.Aeson (ToJSON, Value(String))
 import Data.Aeson qualified as A
+import Data.Bifunctor (first)
 import Data.Hashable (Hashable)
 import Data.List qualified as List
 import Data.List.NonEmpty (NonEmpty((:|)))
@@ -40,6 +42,7 @@ import Data.Text qualified as T
 import Fmt (Buildable, build, fmt, pretty)
 import GHC.Generics (Generic)
 import Servant (FromHttpApiData(..), ToHttpApiData(..))
+import Text.Interpolation.Nyan
 
 -- $setup
 -- >>> import Fmt (pretty, build)
@@ -221,16 +224,31 @@ instance (Buildable path) => Buildable (QualifiedPath path) where
       Nothing -> build path
 
 instance (FromHttpApiData path) => FromHttpApiData (QualifiedPath path) where
-  parseUrlPiece text
-    | [pathPiece] <- T.splitOn "#" text = do
-        path <- parseUrlPiece @path pathPiece
-        pure $ QualifiedPath Nothing path
-    | [backendPiece, pathPiece] <- T.splitOn "#" text = do
-        backendName <- newBackendName backendPiece
-        path <- parseUrlPiece @path pathPiece
-        pure $ QualifiedPath (Just backendName) path
-    | otherwise =
-        Left "Invalid qualified path format. Expected [BACKENDNAME#]PATH"
+  parseUrlPiece = mkQualifiedPath
+    (\_ -> "Invalid qualified path format. Expected [BACKENDNAME#]PATH")
+    parseUrlPiece
+
+mkQualifiedPath
+  :: (Text -> Text)
+  -> (Text -> Either Text path)
+  -> (Text -> Either Text (QualifiedPath path))
+mkQualifiedPath errorMessage mkPath text = case T.splitOn "#" text of
+  [backendNameStr, pathStr] -> do
+    backendName <- readBackendName' backendNameStr
+    path <- mkPath pathStr
+    pure $ QualifiedPath (Just backendName) path
+  [pathStr] -> do
+    path <- mkPath pathStr
+    pure $ QualifiedPath Nothing path
+  _ -> Left $ errorMessage text
+
+readBackendName' :: Text -> Either Text BackendName
+readBackendName' input =
+  newBackendName input & first \err -> T.pack
+    [int|s|
+      Invalid backend name: #{show input}.
+      #{T.unpack err}
+    |]
 
 instance (ToHttpApiData path, Buildable path) => ToHttpApiData (QualifiedPath path) where
   toUrlPiece = pretty

--- a/tests/golden/common/common.bats
+++ b/tests/golden/common/common.bats
@@ -43,7 +43,6 @@ EOF
 
   assert_failure
   assert_output --partial - <<EOF
-Invalid backend name: "bad\nbackend".
 Backend name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'
 EOF
 }
@@ -67,6 +66,10 @@ Invalid qualified entry path format: "back#/path#\n\nsmth".
 Expected format is: [<backend-name>#]<entry-path>.
 <backend-name> can be a string of the following characters: [a-zA-Z0-9] and symbols '-', '_', ';'.
 Examples: 'vault_kv-backend#secrets/google', 'my/passwords/entry'.
+
+Parser error:
+Too many # literals.
+Expected format is: [<backend-name>#]<path>.
 EOF
 }
 
@@ -79,6 +82,10 @@ Invalid qualified path format: "back#/path#\n\nsmth".
 Expected format is: [<backend-name>#]<path>.
 <backend-name> can be a string of the following characters: [a-zA-Z0-9] and symbols '-', '_', ';'.
 Examples: 'vault_kv-backend#secrets/google', 'my/passwords/mypage/'.
+
+Parser error:
+Too many # literals.
+Expected format is: [<backend-name>#]<path>.
 EOF
 }
 


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
## Problem:
We had a lot of repeating code in `FromHttpApiData` instances with `CLI.Parse`.

## Solution:
That was fixed.
Basically a lot of low parsing logic moved from `CLI.Parse` to `CLI.Types` and `Coffer.Path`.
It was necessary to avoid cyclic dependencies.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

- Resolves #89 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
