### PR TITLE
[#120] Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,16 @@ MAKE_PACKAGE = $(MAKEU) PACKAGE=coffer
 
 coffer:
 	$(MAKE_PACKAGE) dev
+
+# Runs all tests.
+# Usage:
+#  * make test
+#  * make test BATSFILTER='test name' TEST_ARGUMENTS='--pattern "test name"' DOCTEST_ARGUMENTS='--verbose'
 test:
-	$(MAKE_PACKAGE) test
+	make doctest
+	make test-unit
+	make server-integration
+	make bats
 test-dumb-term:
 	$(MAKE_PACKAGE) test-dumb-term
 test-hide-successes:
@@ -30,12 +38,21 @@ stylish:
 lint:
 	hlint .
 
+####################################
+# Individual test suites
+
+doctest:
+	stack test --fast coffer:test:doctests --test-arguments "$(DOCTEST_ARGUMENTS)"
+
+test-unit:
+	$(MAKEU) test PACKAGE="coffer:test:test"
+
 server-integration:
 	$(MAKEU) test PACKAGE="coffer:test:server-integration"
 
 # Usage:
 #   * make bats
-#   * make bats FILTER="test name"
+#   * make bats BATSFILTER="test name"
 bats:
 	git submodule update --init --recursive
-	./scripts/run-bats-tests.sh $(if $(FILTER),"$(FILTER)",)
+	./scripts/run-bats-tests.sh $(if $(BATSFILTER),"$(BATSFILTER)",)

--- a/Makefile
+++ b/Makefile
@@ -54,5 +54,6 @@ server-integration:
 #   * make bats
 #   * make bats BATSFILTER="test name"
 bats:
+	stack install --fast coffer:exe:coffer
 	git submodule update --init --recursive
 	./scripts/run-bats-tests.sh $(if $(BATSFILTER),"$(BATSFILTER)",)

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,3 @@ server-integration:
 bats:
 	git submodule update --init --recursive
 	./scripts/run-bats-tests.sh $(if $(FILTER),"$(FILTER)",)
-
-all:
-	$(MAKEU) PACKAGE=""
-test-all:
-	$(MAKEU) test PACKAGE=""

--- a/README.md
+++ b/README.md
@@ -195,29 +195,31 @@ zlib
 
 ## Testing
 
-### `Golden` Tests
-Before you run `golden` tests you need to obtain a `coffer` executable. You can get it in two ways:
-1. Cabal
-```shell
-$ cabal install
-```
-2. Stack
-```shell
-$ stack install
-```
-These commands would build the project and add a symblink for a `coffer` executable.
+The package contains 4 test suites:
+1. A unit tests suite for the coffer library, `coffer:test:test`.
+1. An integration test suite for the Web API, `coffer:test:server-integration`.
+1. A set of golden tests written in `bats` for the coffer executable.
+1. A Haskell doctest suite, `coffer:test:doctests`.
 
-Now you can run `golden` tests with next command:
-```shell
-$ make bats
-```
+Use `make test` to run all test suites:
 
-### Haskell Tests
-These test suites are easier to run than `golden` tests. You can run all tests with this command:
-```shell
+```sh
 $ make test
+
+$ make test \
+    TEST_ARGUMENTS='--pattern "test name"' \
+    BATSFILTER='test name' \
+    DOCTEST_ARGUMENTS='--verbose'
 ```
-Also we have a special task in `Makefile` which runs only `server-integration` test suite (this test suite is included in `test` task).
-```shell
-$ make server-integration
+
+You can also run an individual test suite:
+
+```sh
+$ make test-unit TEST_ARGUMENTS='--pattern "test name"'
+
+$ make server-integration TEST_ARGUMENTS='--pattern "test name"'
+
+$ make bats BATSFILTER='test name'
+
+$ make doctest DOCTEST_ARGUMENTS='--verbose'
 ```

--- a/scripts/run-bats-tests.sh
+++ b/scripts/run-bats-tests.sh
@@ -7,7 +7,7 @@
 # This script runs two vault instances,
 # then runs bats tests and finally kills the vault instances.
 
-FILTER=$1
+BATSFILTER=$1
 
 vault server -dev -dev-root-token-id="root" -dev-listen-address="localhost:8209" > /dev/null 2>&1 &
 vault1_pid=$!
@@ -15,10 +15,10 @@ vault1_pid=$!
 vault server -dev -dev-root-token-id="second" -dev-listen-address="localhost:8211" > /dev/null 2>&1 &
 vault2_pid=$!
 
-if [ -z "$FILTER" ]; then
+if [ -z "$BATSFILTER" ]; then
   ./tests/golden/helpers/bats/bin/bats ./tests/golden/**
 else
-  ./tests/golden/helpers/bats/bin/bats ./tests/golden/** -f "$FILTER"
+  ./tests/golden/helpers/bats/bin/bats ./tests/golden/** -f "$BATSFILTER"
 fi
 
 kill $vault1_pid > /dev/null 2>&1


### PR DESCRIPTION
## Description

There are a few issues with the makefile:

* The `test-all` and `all` targets do the same thing as `test` and `coffer`, so they're redundant
* The `test` target does not include golden tests
* The `test` target calls the doctests executable with `--color`, but doctests does not recognize this option.

This PR:
* removes those redundant targets
* fixes `make test` so that it runs all test suites
* does not call doctest with `--color`
* adds makefile targets for each individual test suite
* updates the readme to reflect these changes

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #120

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
