### PR TITLE
[#113] Drop support for qualified paths in Web API

### DIFF
--- a/lib/Web/API.hs
+++ b/lib/Web/API.hs
@@ -7,7 +7,7 @@ module Web.API where
 import Backends (SomeBackend)
 import CLI.Types
 import Coffer.Directory (Directory)
-import Coffer.Path (EntryPath, Path, QualifiedPath)
+import Coffer.Path (EntryPath, Path)
 import Data.Text (Text)
 import Entry
 import GHC.Generics (Generic)
@@ -18,17 +18,17 @@ type API
   = Header' [Required, Strict] "Coffer-Backend" SomeBackend
   :> "api" :> "v1" :> "content" :>
     ( "view"
-      :> RequiredParam "path"  (QualifiedPath Path)
+      :> RequiredParam "path" Path
       :> Get '[JSON] Directory
 
     :<|> "create"
-      :> RequiredParam "path" (QualifiedPath EntryPath)
+      :> RequiredParam "path" EntryPath
       :> QueryFlag     "force"
       :> ReqBody '[JSON] NewEntry
       :> Post '[JSON] Entry
 
     :<|> "set-field"
-      :> RequiredParam "path" (QualifiedPath EntryPath)
+      :> RequiredParam "path" EntryPath
       :> RequiredParam "field" FieldName
       :>
         (    "private" :> Post '[JSON] Entry
@@ -38,12 +38,12 @@ type API
         )
 
     :<|> "delete-field"
-      :> RequiredParam "path" (QualifiedPath EntryPath)
+      :> RequiredParam "path" EntryPath
       :> RequiredParam "field" FieldName
       :> Delete '[JSON] Entry
 
     :<|> "find"
-      :> OptionalParam  "path" (QualifiedPath Path)
+      :> OptionalParam  "path" Path
       :> OptionalParam  "text" Text
       :> OptionalParam  "sort-field" (Sort, Direction)
       :> OptionalParams "filter" Filter
@@ -51,26 +51,26 @@ type API
 
     :<|> "rename"
       :> QueryFlag     "dry-run"
-      :> RequiredParam "old-path" (QualifiedPath Path)
-      :> RequiredParam "new-path" (QualifiedPath Path)
+      :> RequiredParam "old-path" Path
+      :> RequiredParam "new-path" Path
       :> QueryFlag     "force"
       :> Post '[JSON] [(EntryPath, EntryPath)]
 
     :<|> "copy"
       :> QueryFlag     "dry-run"
-      :> RequiredParam "old-path" (QualifiedPath Path)
-      :> RequiredParam "new-path" (QualifiedPath Path)
+      :> RequiredParam "old-path" Path
+      :> RequiredParam "new-path" Path
       :> QueryFlag     "force"
       :> Post '[JSON] [(EntryPath, EntryPath)]
 
     :<|> "delete"
       :> QueryFlag     "dry-run"
-      :> RequiredParam "path" (QualifiedPath Path)
+      :> RequiredParam "path" Path
       :> QueryFlag     "recursive"
       :> DeleteNoContent
 
     :<|> "tag"
-      :> RequiredParam "path" (QualifiedPath EntryPath)
+      :> RequiredParam "path" EntryPath
       :> RequiredParam "tag" EntryTag
       :>
         (    Post   '[JSON] Entry


### PR DESCRIPTION
Problem:
We no longer need `QualifiedPath` in `Web API`

Solution:
Removing `QualifiedPath` from `Web API` endpoints
`Web.Server` now makes every `QualifiedPath` without `BackendName`

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #113 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
