### PR TITLE
[#118] Fix unsafe Json http api data instances

### DIFF
--- a/coffer.cabal
+++ b/coffer.cabal
@@ -331,6 +331,7 @@ test-suite server-integration
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Common.Common
       CopyAndRename.Common
       CopyAndRename.CopyTest
       CopyAndRename.RenameTest

--- a/lib/Entry.hs
+++ b/lib/Entry.hs
@@ -62,9 +62,9 @@ newtype BadFieldName = BadFieldName { unBadFieldName :: Text }
 newFieldName :: Text -> Either BadFieldName FieldName
 newFieldName t
   | T.null t =
-      Left $ BadFieldName "Tags must contain at least 1 character"
+      Left $ BadFieldName "Field name must contain at least 1 character"
   | T.any (`notElem` allowedCharSet) t =
-      Left $ BadFieldName ("Tags can only contain the following characters: '" <> T.pack allowedCharSet <> "'")
+      Left $ BadFieldName ("Field name can only contain the following characters: '" <> T.pack allowedCharSet <> "'")
   | otherwise = Right $ UnsafeFieldName t
 
 getFieldName :: FieldName -> Text

--- a/tests/golden/common/common.bats
+++ b/tests/golden/common/common.bats
@@ -53,7 +53,7 @@ EOF
   assert_failure
   assert_output --partial - <<EOF
 Invalid field name: "bad\nfieldname".
-Tags can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'
+Field name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'
 EOF
 }
 

--- a/tests/server-integration/Common/Common.hs
+++ b/tests/server-integration/Common/Common.hs
@@ -1,0 +1,91 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module Common.Common
+  ( unit_incorrect_backend_name
+  , unit_incorrect_field_name_fromJSON
+  , unit_incorrect_field_name_fromHttpApiData
+  ) where
+
+import Control.Exception
+import Data.Aeson (encode)
+import Data.Aeson.QQ.Simple (aesonQQ)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text
+import Network.HTTP.Client (Response(responseStatus))
+import Network.HTTP.Req
+import Network.HTTP.Types (status400)
+import Test.Tasty.HUnit
+import Utils
+  (cofferTest, createEntry, executeCommand, executeCommandWithHeader, setField,
+  unwarpStatusCodeError)
+
+unit_incorrect_backend_name :: IO ()
+unit_incorrect_backend_name = cofferTest do
+  try @HttpException
+    (executeCommandWithHeader
+        errHeader
+        POST
+        ["create"]
+        (ReqBodyJson emptyNewEntry)
+        ignoreResponse
+        ("path" =: ("entry" :: Text))
+      ) >>= unwarpStatusCodeError \response bs -> do
+        bs @?= "Error parsing header Coffer-Backend failed: Error in $.name: Backend name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
+        responseStatus response @?= status400
+    where
+    emptyNewEntry =
+      [aesonQQ|
+        {
+          "fields": { },
+          "tags": []
+        }
+      |]
+    errHeader = LBS.toStrict . encode $
+      [aesonQQ|
+          {
+            "type" : "vault-kv",
+            "name" : "vault-local#",
+            "address" : "localhost:8212",
+            "mount" : "secret",
+            "token" : "root"
+          }
+      |]
+
+unit_incorrect_field_name_fromJSON :: IO()
+unit_incorrect_field_name_fromJSON = cofferTest do
+  try @HttpException
+    (executeCommand
+        POST
+        ["create"]
+        (ReqBodyJson emptyNewEntry)
+        ignoreResponse
+        ("path" =: ("entry" :: Text))
+      ) >>= unwarpStatusCodeError \response bs -> do
+        bs @?= "Error in $.fields['fieldname:.']: Field name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
+        responseStatus response @?= status400
+    where
+    emptyNewEntry =
+      [aesonQQ|
+        {
+          "fields":
+            {
+              "fieldname:." :
+                {
+                  "contents" : "contents",
+                  "visibility" : "public"
+                }
+            },
+          "tags": []
+        }
+      |]
+
+unit_incorrect_field_name_fromHttpApiData :: IO()
+unit_incorrect_field_name_fromHttpApiData = cofferTest do
+  createEntry "entry"
+
+  try @HttpException ( setField "entry" "fieldname:." "contents" )
+    >>= unwarpStatusCodeError \response bs -> do
+      bs @?= "Error parsing query parameter field failed: Field name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
+      responseStatus response @?= status400


### PR DESCRIPTION
## Description

### Problem:

`FieldName` used unsafe(default text) constructors
for `FromJSON`, `FromJSONKey`  and `FromHttpApiData`

### Solution:

Write new safe instances that use smart `newFieldName` constructor. 
Cover new functionality with bad-case tests
Also corrected previous Error msg.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #118 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
