### PR TITLE
[#118] Fix unsafe Json http api data instances

### DIFF
--- a/coffer.cabal
+++ b/coffer.cabal
@@ -331,6 +331,7 @@ test-suite server-integration
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Common.Common
       CopyAndRename.Common
       CopyAndRename.CopyTest
       CopyAndRename.RenameTest

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -54,15 +54,11 @@ import Text.Interpolation.Nyan
 
 newtype PathSegment = UnsafeMkPathSegment { unPathSegment :: Text }
   deriving stock (Show, Eq, Generic)
-  deriving newtype (Buildable, ToHttpApiData, FromHttpApiData)
+  deriving newtype (Buildable, ToHttpApiData)
   deriving newtype (Hashable, A.ToJSON, A.ToJSONKey)
 
-data DirectoryContents = DirectoryContents
-  { dcDirectoryNames :: [PathSegment]
-  , dcEntryNames :: [PathSegment]
-  }
-  deriving stock (Show)
-makeLensesWith abbreviatedFields ''DirectoryContents
+instance FromHttpApiData PathSegment where
+  parseUrlPiece = mkPathSegment
 
 mkPathSegment :: Text -> Either Text PathSegment
 mkPathSegment segment
@@ -74,6 +70,13 @@ mkPathSegment segment
 
 pathSegmentAllowedCharacters :: [Char]
 pathSegmentAllowedCharacters = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ "-_"
+
+data DirectoryContents = DirectoryContents
+  { dcDirectoryNames :: [PathSegment]
+  , dcEntryNames :: [PathSegment]
+  }
+  deriving stock (Show)
+makeLensesWith abbreviatedFields ''DirectoryContents
 
 -- | Path to a directory or an entry.
 newtype Path = Path { unPath :: [PathSegment] }

--- a/lib/Entry.hs
+++ b/lib/Entry.hs
@@ -91,7 +91,17 @@ getFieldName (UnsafeFieldName t) = t
 
 newtype EntryTag = UnsafeEntryTag Text
   deriving stock (Show, Eq, Ord)
-  deriving newtype (A.ToJSON, A.FromJSON, Buildable, Hashable, ToHttpApiData, FromHttpApiData)
+  deriving newtype (A.ToJSON, Buildable, Hashable, ToHttpApiData)
+
+instance A.FromJSON EntryTag where
+  parseJSON = withText "FieldName" $
+    (\case
+      Right entryTag -> return entryTag
+      Left err -> fail $ T.unpack . unBadEntryTag $ err
+    ) . newEntryTag
+
+instance FromHttpApiData EntryTag where
+  parseUrlPiece text = first unBadEntryTag $ newEntryTag text
 
 newtype BadEntryTag = BadEntryTag { unBadEntryTag :: Text }
   deriving newtype Buildable

--- a/lib/Entry.hs
+++ b/lib/Entry.hs
@@ -62,9 +62,9 @@ newtype BadFieldName = BadFieldName { unBadFieldName :: Text }
 newFieldName :: Text -> Either BadFieldName FieldName
 newFieldName t
   | T.null t =
-      Left $ BadFieldName "Tags must contain at least 1 character"
+      Left $ BadFieldName "Field name must contain at least 1 character"
   | T.any (`notElem` allowedCharSet) t =
-      Left $ BadFieldName ("Tags can only contain the following characters: '" <> T.pack allowedCharSet <> "'")
+      Left $ BadFieldName ("Field name can only contain the following characters: '" <> T.pack allowedCharSet <> "'")
   | otherwise = Right $ UnsafeFieldName t
 
 getFieldName :: FieldName -> Text

--- a/tests/golden/common/common.bats
+++ b/tests/golden/common/common.bats
@@ -53,7 +53,7 @@ EOF
   assert_failure
   assert_output --partial - <<EOF
 Invalid field name: "bad\nfieldname".
-Tags can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'
+Field name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'
 EOF
 }
 

--- a/tests/server-integration/Common/Common.hs
+++ b/tests/server-integration/Common/Common.hs
@@ -6,6 +6,8 @@ module Common.Common
   ( unit_incorrect_backend_name
   , unit_incorrect_field_name_fromJSONKey
   , unit_incorrect_field_name_fromHttpApiData
+  , unit_incorrect_tag_name_fromJSON
+  , unit_incorrect_tag_name_fromHttpApiData
   ) where
 
 import Control.Exception
@@ -18,8 +20,6 @@ import Network.HTTP.Req
 import Network.HTTP.Types (status400)
 import Test.Tasty.HUnit
 import Utils
-  (cofferTest, createEntry, executeCommand, executeCommandWithHeader, setField,
-  unwrapStatusCodeError)
 
 unit_incorrect_backend_name :: IO ()
 unit_incorrect_backend_name = cofferTest do
@@ -88,4 +88,34 @@ unit_incorrect_field_name_fromHttpApiData = cofferTest do
   try @HttpException ( setField "entry" "fieldname:." "contents" )
     >>= unwrapStatusCodeError \response bs -> do
       bs @?= "Error parsing query parameter field failed: Field name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
+      responseStatus response @?= status400
+
+unit_incorrect_tag_name_fromJSON :: IO()
+unit_incorrect_tag_name_fromJSON = cofferTest do
+  try @HttpException
+    (executeCommand
+        POST
+        ["create"]
+        (ReqBodyJson emptyNewEntry)
+        ignoreResponse
+        ("path" =: ("entry" :: Text))
+      ) >>= unwrapStatusCodeError \response bs -> do
+        bs @?= "Error in $.tags[0]: Tags can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
+        responseStatus response @?= status400
+    where
+    emptyNewEntry =
+      [aesonQQ|
+        {
+          "fields": {},
+          "tags": [ "tag:." ]
+        }
+      |]
+
+unit_incorrect_tag_name_fromHttpApiData :: IO ()
+unit_incorrect_tag_name_fromHttpApiData = cofferTest do
+  createEntry "tagged"
+
+  try @HttpException ( addOrRemoveTag POST "tagged" "tag:." )
+    >>= unwrapStatusCodeError \response bs -> do
+      bs @?= "Error parsing query parameter tag failed: Tags can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
       responseStatus response @?= status400

--- a/tests/server-integration/Common/Common.hs
+++ b/tests/server-integration/Common/Common.hs
@@ -8,6 +8,7 @@ module Common.Common
   , unit_incorrect_field_name_fromHttpApiData
   , unit_incorrect_tag_name_fromJSON
   , unit_incorrect_tag_name_fromHttpApiData
+  , unit_incorrect_path_segment_fromHttpApiData
   ) where
 
 import Control.Exception
@@ -118,4 +119,12 @@ unit_incorrect_tag_name_fromHttpApiData = cofferTest do
   try @HttpException ( addOrRemoveTag POST "tagged" "tag:." )
     >>= unwrapStatusCodeError \response bs -> do
       bs @?= "Error parsing query parameter tag failed: Tags can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
+      responseStatus response @?= status400
+
+unit_incorrect_path_segment_fromHttpApiData :: IO ()
+unit_incorrect_path_segment_fromHttpApiData = cofferTest do
+
+  try @HttpException ( createEntry "entry:." )
+    >>= unwrapStatusCodeError \response bs -> do
+      bs @?= "Error parsing query parameter path failed: Path segments can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'"
       responseStatus response @?= status400

--- a/tests/server-integration/Common/Common.hs
+++ b/tests/server-integration/Common/Common.hs
@@ -1,0 +1,91 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module Common.Common
+  ( unit_incorrect_backend_name
+  , unit_incorrect_field_name_fromJSONKey
+  , unit_incorrect_field_name_fromHttpApiData
+  ) where
+
+import Control.Exception
+import Data.Aeson (encode)
+import Data.Aeson.QQ.Simple (aesonQQ)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text
+import Network.HTTP.Client (Response(responseStatus))
+import Network.HTTP.Req
+import Network.HTTP.Types (status400)
+import Test.Tasty.HUnit
+import Utils
+  (cofferTest, createEntry, executeCommand, executeCommandWithHeader, setField,
+  unwrapStatusCodeError)
+
+unit_incorrect_backend_name :: IO ()
+unit_incorrect_backend_name = cofferTest do
+  try @HttpException
+    (executeCommandWithHeader
+        errHeader
+        POST
+        ["create"]
+        (ReqBodyJson emptyNewEntry)
+        ignoreResponse
+        ("path" =: ("entry" :: Text))
+      ) >>= unwrapStatusCodeError \response bs -> do
+        bs @?= "Error parsing header Coffer-Backend failed: Error in $.name: Backend name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
+        responseStatus response @?= status400
+    where
+    emptyNewEntry =
+      [aesonQQ|
+        {
+          "fields": { },
+          "tags": []
+        }
+      |]
+    errHeader = LBS.toStrict . encode $
+      [aesonQQ|
+          {
+            "type" : "vault-kv",
+            "name" : "vault-local#",
+            "address" : "localhost:8212",
+            "mount" : "secret",
+            "token" : "root"
+          }
+      |]
+
+unit_incorrect_field_name_fromJSONKey :: IO()
+unit_incorrect_field_name_fromJSONKey = cofferTest do
+  try @HttpException
+    (executeCommand
+        POST
+        ["create"]
+        (ReqBodyJson emptyNewEntry)
+        ignoreResponse
+        ("path" =: ("entry" :: Text))
+      ) >>= unwrapStatusCodeError \response bs -> do
+        bs @?= "Error in $.fields['fieldname:.']: Field name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
+        responseStatus response @?= status400
+    where
+    emptyNewEntry =
+      [aesonQQ|
+        {
+          "fields":
+            {
+              "fieldname:." :
+                {
+                  "contents" : "contents",
+                  "visibility" : "public"
+                }
+            },
+          "tags": []
+        }
+      |]
+
+unit_incorrect_field_name_fromHttpApiData :: IO()
+unit_incorrect_field_name_fromHttpApiData = cofferTest do
+  createEntry "entry"
+
+  try @HttpException ( setField "entry" "fieldname:." "contents" )
+    >>= unwrapStatusCodeError \response bs -> do
+      bs @?= "Error parsing query parameter field failed: Field name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
+      responseStatus response @?= status400

--- a/tests/server-integration/Tag/TagTest.hs
+++ b/tests/server-integration/Tag/TagTest.hs
@@ -14,32 +14,12 @@ module Tag.TagTest
 import Control.Exception (try)
 import Control.Lens
 import Control.Monad (void)
-import Data.Aeson
 import Data.Aeson.Lens
 import Data.Aeson.QQ.Simple (aesonQQ)
-import Data.Text (Text)
 import Data.Time
 import Network.HTTP.Req
 import Network.HTTP.Types (status404, status409)
 import Utils
-
-addOrRemoveTag
-  ::
-   ( HttpMethod method
-   , HttpBodyAllowed (AllowsBody method) 'NoBody
-   )
-   => method -> Text -> Text -> IO (JsonResponse Value)
-addOrRemoveTag method path tag =
-  executeCommand
-    method
-    ["tag"]
-    NoReqBody
-    (jsonResponse @Value)
-    ( mconcat
-        [ "path" =: path
-        , "tag" =: tag
-        ]
-    )
 
 unit_tag_entry :: IO ()
 unit_tag_entry = cofferTest do

--- a/tests/server-integration/Utils.hs
+++ b/tests/server-integration/Utils.hs
@@ -19,7 +19,7 @@ module Utils
   , unwrapStatusCodeError
   , checkOnlyEntryModifiedDateUpdated
   , executeDeleteCommand
-  ) where
+  , addOrRemoveTag) where
 
 import Control.Exception (Exception(displayException), try)
 import Control.Lens
@@ -245,5 +245,23 @@ executeDeleteCommand path recursive =
     ( mconcat
         [ "path" =: path
         , if recursive then queryFlag "recursive" else mempty
+        ]
+    )
+
+addOrRemoveTag
+  ::
+   ( HttpMethod method
+   , HttpBodyAllowed (AllowsBody method) 'NoBody
+   )
+   => method -> Text -> Text -> IO (JsonResponse Value)
+addOrRemoveTag method path tag =
+  executeCommand
+    method
+    ["tag"]
+    NoReqBody
+    (jsonResponse @Value)
+    ( mconcat
+        [ "path" =: path
+        , "tag" =: tag
         ]
     )

--- a/tests/server-integration/Utils.hs
+++ b/tests/server-integration/Utils.hs
@@ -13,8 +13,10 @@ module Utils
   , findField
   , viewRoot
   , executeCommand
+  , executeCommandWithHeader
   , (@=)
   , processStatusCodeError
+  , unwrapStatusCodeError
   , checkOnlyEntryModifiedDateUpdated
   , executeDeleteCommand
   ) where
@@ -25,15 +27,15 @@ import Control.Monad (void)
 import Data.Aeson (Object, Value(String), eitherDecodeStrict, encode)
 import Data.Aeson.Lens
 import Data.Aeson.QQ.Simple (aesonQQ)
-import Data.ByteString.Internal qualified as BS
-import Data.ByteString.Lazy qualified as BS (toStrict)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS (toStrict)
 import Data.Generics
 import Data.Text (Text)
 import Data.Time
 import GHC.IO.Handle (Handle)
 import Network.HTTP.Client
   (HttpException(HttpExceptionRequest), HttpExceptionContent(StatusCodeException),
-  Response(responseStatus))
+  Response(responseHeaders, responseStatus))
 import Network.HTTP.Req
 import Network.HTTP.Req qualified as Req (HttpException)
 import Network.HTTP.Types (Status)
@@ -148,7 +150,7 @@ viewRoot = do
   pure $ responseBody response
 
 makeCofferHeader :: BS.ByteString
-makeCofferHeader =  BS.toStrict . encode $
+makeCofferHeader =  LBS.toStrict . encode $
   [aesonQQ|
       {
         "type" : "vault-kv",
@@ -158,6 +160,34 @@ makeCofferHeader =  BS.toStrict . encode $
         "token" : "root"
       }
   |]
+
+executeCommandWithHeader
+  ::
+   ( HttpBodyAllowed (AllowsBody method) (ProvidesBody body)
+   , HttpMethod method, HttpBody body, HttpResponse response
+   )
+   => BS.ByteString
+   -> method
+   -> [Text]
+   -> body
+   -> Proxy response
+   -> Option 'Http
+   -> IO response
+executeCommandWithHeader cofferHeader method urlParts body proxy options =
+  runReq defaultHttpConfig do
+    req
+      method
+      url
+      body
+      proxy
+      ( mconcat
+          [ header "Coffer-Backend" cofferHeader
+          , port 8081
+          , options
+          ]
+      )
+  where
+    url = foldl (/:) baseUrl urlParts
 
 executeCommand
   ::
@@ -170,33 +200,28 @@ executeCommand
    -> Proxy response
    -> Option 'Http
    -> IO response
-executeCommand method urlParts body proxy options =
-  runReq defaultHttpConfig do
-    req
-      method
-      url
-      body
-      proxy
-      ( mconcat
-          [ header "Coffer-Backend" makeCofferHeader
-          , port 8081
-          , options
-          ]
-      )
-  where
-    url = foldl (/:) baseUrl urlParts
+executeCommand = executeCommandWithHeader makeCofferHeader
 
 (@=) :: JsonResponse Value -> Value -> IO ()
 response @= value = scrubDates (responseBody response) @?= value
 
 processStatusCodeError :: (Show res) => Status -> Value -> Either Req.HttpException res -> IO ()
-processStatusCodeError expectedStatus jsonBodyExpected = \case
+processStatusCodeError expectedStatus jsonBodyExpected = unwrapStatusCodeError $ \response bs ->
+  case lookup "Content-Type" $ responseHeaders response of
+    Just "application/json;charset=utf-8" -> do
+      jsonBodyActual <- either assertFailure pure $ eitherDecodeStrict @Value bs
+      jsonBodyActual @?= jsonBodyExpected
+      responseStatus response @?= expectedStatus
+    Just contentType -> assertFailure $ "Unexpected content-type header : " <> show contentType
+    Nothing -> do
+      assertFailure "No content-type header was specified"
+
+unwrapStatusCodeError :: (Show res) => (Response () -> BS.ByteString -> IO()) -> Either Req.HttpException res -> IO()
+unwrapStatusCodeError validator = \case
   Right res -> assertFailure $ "Expected http exception, got " <> show res
-  Left (VanillaHttpException (HttpExceptionRequest _ (StatusCodeException response bs))) -> do
-    jsonBodyActual <- either assertFailure pure $ eitherDecodeStrict @Value bs
-    jsonBodyActual @?= jsonBodyExpected
-    responseStatus response @?= expectedStatus
+  Left (VanillaHttpException (HttpExceptionRequest _ (StatusCodeException response bs))) -> validator response bs
   Left httpExc -> assertFailure $ "Expected http exception, got " <> displayException httpExc
+
 
 -- Checks, that after some modifying action only entry's modified date updates.
 checkOnlyEntryModifiedDateUpdated :: Value -> Value -> UTCTime -> UTCTime -> UTCTime -> Text -> IO ()


### PR DESCRIPTION
## Description

### Problem:

`FieldName`, `EntryTag`, `PathSegment` used unsafe(default text) constructors
for `FromJSON`, `FromJSONKey`  and `FromHttpApiData`

### Solution:

Write new safe instances that use smart `newFieldName` constructor. 
Cover new functionality with bad-case tests
Also corrected previous Error msg.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #118 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
