### PR TITLE
[#85] make the port number configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,31 @@ The coffer CLI will look for its configuration file in the following order:
 
 ### Web API
 
-Coffer also has a Web API. Currently, it runs on `localhost:8081`. In the future we could configure this but at this moment we can't.
+Coffer also has a Web API. The port can be specified via:
+- Cmd line option: `--port`
+- Environment variable: `"COFFER_SERVER_PORT"`
 
-You can run server in the following ways:
-1. Cabal
+Examples:
+1. Stack
 ```shell
-$ cabal run coffer-server
+$ stack run -- coffer-server --port=8081
 ```
-2. Stack
+
 ```shell
+$ export COFFER_SERVER_PORT=8081
 $ stack run coffer-server
 ```
+
+2. Cabal
+```shell
+$ cabal run -- coffer-server --port=8081
+```
+
+```shell
+$ export COFFER_SERVER_PORT=8081
+$ cabal run coffer-server
+```
+
 
 Documentation for Web API endpoints and their return types could be generated via `servant-openapi3`. (TODO: write something about docs generation after [#114](https://github.com/serokell/coffer/issues/114) is resolved).
 

--- a/coffer.cabal
+++ b/coffer.cabal
@@ -331,6 +331,7 @@ test-suite server-integration
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Common.BootServer
       Common.Common
       CopyAndRename.Common
       CopyAndRename.CopyTest

--- a/coffer.cabal
+++ b/coffer.cabal
@@ -414,6 +414,7 @@ test-suite server-integration
     , lens-aeson
     , process
     , req
+    , silently
     , syb
     , tasty
     , tasty-hunit

--- a/lib/Web/Main.hs
+++ b/lib/Web/Main.hs
@@ -4,18 +4,72 @@
 
 module Web.Main
   ( runServer
+  , RunServerException (..)
   ) where
 
 import Backend.Commands (runCommand)
 import Config
+import Control.Exception (Exception, throw)
+import Data.Bifunctor (Bifunctor(first))
+import Data.Either (partitionEithers)
 import Data.Proxy
 import Network.Wai.Handler.Warp (run)
+import Options.Applicative
 import Servant.Server (serve)
+import System.Environment (lookupEnv)
+import Text.Interpolation.Nyan
+import Text.Read (readEither)
 import Web.API (API)
 import Web.Server
 
+data ServerOptions = ServerOptions { serverPort :: Maybe Int }
+
+data RunServerException
+  = RunServerIncorrectPort Int
+  | RunServerNoPortSpecified
+  | RunServerEnvVarParseFail String
+  deriving stock (Eq)
+
+instance Show RunServerException where
+  show (RunServerIncorrectPort port) = "Port number should be greater than 0. Your port number is: " ++ show port
+  show RunServerNoPortSpecified = "No port was specified. It can be set using the environment variable \"COFFER_SERVER_PORT\" or the \"--port=$port_num\" command-line option."
+  show (RunServerEnvVarParseFail msg) = "Can't parse port specified by the environment variable \"COFFER_SERVER_PORT\": " ++ msg
+
+instance Exception RunServerException
+
+parseServerOptions :: ParserInfo ServerOptions
+parseServerOptions = info (parser <**> helper) mempty
+
+parser ::  Parser ServerOptions
+parser = ServerOptions <$> parseServerOptionPort
+
+parseServerOptionPort :: Parser (Maybe Int)
+parseServerOptionPort = optional $ option auto $ mconcat
+        [ long "port"
+        , short 'p'
+        , metavar "COFFER_SERVER_PORT"
+        , help [int|s|
+            Specify the server port to run a server.
+            When this option is not set, the 'COFFER_SERVER_PORT' environment variable will be used.
+            When neither is set, it will crash.
+          |]
+        ]
+
 runServer :: IO ()
 runServer = do
-  run 8081 do
-    serve (Proxy :: Proxy API) do
-      makeServer \someBackend -> reportErrors . runBackendIO' . runCommand (makeSingleBackendConfig  someBackend)
+  opts <- execParser parseServerOptions
+  envPortStr <- lookupEnv "COFFER_SERVER_PORT"
+
+  let envPort = maybe (Left RunServerNoPortSpecified) ((first RunServerEnvVarParseFail) . readEither) envPortStr
+  let optPort = maybe (Left RunServerNoPortSpecified) Right $ serverPort opts
+
+  let (errs, ports) = partitionEithers [optPort, envPort]
+
+  case ports of
+    (port : _) -> do
+      if 0 < port
+      then run port $ serve (Proxy :: Proxy API) do
+        makeServer \someBackend ->
+          reportErrors . runBackendIO' . runCommand (makeSingleBackendConfig  someBackend)
+      else throw $ RunServerIncorrectPort port
+    _ -> throw $ last errs

--- a/package.yaml
+++ b/package.yaml
@@ -184,3 +184,4 @@ tests:
       - text
       - time
       - bytestring
+      - silently

--- a/package.yaml
+++ b/package.yaml
@@ -117,6 +117,7 @@ library:
     - unordered-containers
     - validation-selective
     - warp
+    - optparse-applicative
 
 executables:
   coffer:

--- a/tests/server-integration/Common/BootServer.hs
+++ b/tests/server-integration/Common/BootServer.hs
@@ -17,6 +17,8 @@ import Control.Concurrent.Async (async, cancel, poll)
 import Control.Exception (SomeException(SomeException))
 import Control.Monad.Extra (whenJust)
 import System.Environment (setEnv, unsetEnv, withArgs)
+import System.IO (stderr)
+import System.IO.Silently (hCapture)
 import System.Time.Extra (sleep)
 import Test.Tasty.HUnit (assertFailure, (@=?))
 import Web.Main (RunServerException(..), runServer)
@@ -27,7 +29,7 @@ testPort = "8079"
 testServer :: Maybe String -> [String] -> IO () -> IO () -> (String -> IO ()) -> IO ()
 testServer mbEnvPort args serverRunning serverStopped serverCrashed = do
   whenJust mbEnvPort $ setEnv "COFFER_SERVER_PORT"
-  server <- async $ withArgs args runServer
+  server <- async $ hCapture [stderr] $ withArgs args runServer
   sleep 1
   serverStatus <- poll server
   case serverStatus of

--- a/tests/server-integration/Common/BootServer.hs
+++ b/tests/server-integration/Common/BootServer.hs
@@ -97,6 +97,6 @@ unit_run_with_bad_cmd_opt_and_env_var_port :: IO()
 unit_run_with_bad_cmd_opt_and_env_var_port = testServer
   (Just testPort)
   ["--port=-1"]
-  (assertFailure "Server made prefernce to env var instead of cmd option")
+  (assertFailure "Expected command-line option to take precedence over the env var, but the env var was used instead.")
   (assertFailure "Server ended its work")
   (\err -> show (RunServerIncorrectPort -1) @=? err)

--- a/tests/server-integration/Common/BootServer.hs
+++ b/tests/server-integration/Common/BootServer.hs
@@ -1,0 +1,102 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module Common.BootServer
+  ( unit_run_with_cmd_option_port
+  , unit_run_with_env_var_port
+  , unit_run_with_no_port_specified
+  , unit_run_with_cmd_opt_and_bad_env_var_port
+  , unit_run_with_bad_cmd_opt_and_env_var_port
+  , unit_run_with_bad_env_var_port
+  , unit_run_with_bad_cmd_option_port
+  , unit_run_with_bad_str_cmd_option_port
+  ) where
+
+import Control.Concurrent.Async (async, cancel, poll)
+import Control.Exception (SomeException(SomeException))
+import Control.Monad.Extra (whenJust)
+import System.Environment (setEnv, unsetEnv, withArgs)
+import System.Time.Extra (sleep)
+import Test.Tasty.HUnit (assertFailure, (@=?))
+import Web.Main (RunServerException(..), runServer)
+
+testPort :: String
+testPort = "8079"
+
+testServer :: Maybe String -> [String] -> IO () -> IO () -> (String -> IO ()) -> IO ()
+testServer mbEnvPort args serverRunning serverStopped serverCrashed = do
+  whenJust mbEnvPort $ setEnv "COFFER_SERVER_PORT"
+  server <- async $ withArgs args runServer
+  sleep 1
+  serverStatus <- poll server
+  case serverStatus of
+    Nothing -> cancel server >> serverRunning
+    Just (Right _) -> serverStopped
+    Just (Left (SomeException err)) -> serverCrashed $ show err
+  whenJust mbEnvPort $ \_ -> unsetEnv "COFFER_SERVER_PORT"
+
+unit_run_with_cmd_option_port :: IO ()
+unit_run_with_cmd_option_port = testServer
+  Nothing
+  ["--port=" ++ testPort]
+  (pure ())
+  (assertFailure "Server ended its work")
+  (\err -> assertFailure ("Server raised exception : " ++ show err))
+
+-- can we hide stdout?
+unit_run_with_bad_str_cmd_option_port :: IO()
+unit_run_with_bad_str_cmd_option_port = testServer
+  Nothing
+  ["--port=abs"]
+  (assertFailure "Server is running with bad port env var")
+  (assertFailure "Server successfully ended its work with bad port env var")
+  (\err -> "ExitFailure 1" @=? err)
+
+unit_run_with_bad_cmd_option_port :: IO()
+unit_run_with_bad_cmd_option_port = testServer
+  Nothing
+  ["--port=-1"]
+  (assertFailure "Server is running with bad port env var")
+  (assertFailure "Server successfully ended its work with bad port env var")
+  (\err -> show (RunServerIncorrectPort -1) @=? err)
+
+unit_run_with_env_var_port :: IO()
+unit_run_with_env_var_port = testServer
+  (Just testPort)
+  []
+  (pure ())
+  (assertFailure "Server ended its work")
+  (\err -> assertFailure $ "Server raised exception : " ++ show err)
+
+unit_run_with_bad_env_var_port :: IO()
+unit_run_with_bad_env_var_port = testServer
+  (Just "bad_port")
+  []
+  (assertFailure "Server is running with bad port env var")
+  (assertFailure "Server successfully ended its work with bad port env var")
+  (\err -> show (RunServerEnvVarParseFail "Prelude.read: no parse") @=? err)
+
+unit_run_with_no_port_specified :: IO()
+unit_run_with_no_port_specified =  testServer
+  Nothing
+  []
+  (assertFailure "Server is running without port specified")
+  (assertFailure "Server successfully ended its work without port specified")
+  (\err -> show RunServerNoPortSpecified @=? err)
+
+unit_run_with_cmd_opt_and_bad_env_var_port :: IO()
+unit_run_with_cmd_opt_and_bad_env_var_port = testServer
+  (Just "-1")
+  ["--port=" ++ testPort]
+  (pure ())
+  (assertFailure "Server ended its work")
+  (\err -> assertFailure $ "Server raised exception : " ++ show err)
+
+unit_run_with_bad_cmd_opt_and_env_var_port :: IO()
+unit_run_with_bad_cmd_opt_and_env_var_port = testServer
+  (Just testPort)
+  ["--port=-1"]
+  (assertFailure "Server made prefernce to env var instead of cmd option")
+  (assertFailure "Server ended its work")
+  (\err -> show (RunServerIncorrectPort -1) @=? err)

--- a/tests/server-integration/Main.hs
+++ b/tests/server-integration/Main.hs
@@ -6,7 +6,7 @@ module Main where
 
 import Control.Concurrent.Async (async, cancel)
 import Data.Functor ((<&>))
-import System.Environment (setEnv, unsetEnv)
+import System.Environment (withArgs)
 import System.Process (terminateProcess)
 import System.Time.Extra (sleep)
 import Test.Tasty (defaultMain, localOption, withResource)
@@ -22,15 +22,13 @@ main = do
   let testTree =
         withResource
           do
-            setEnv "COFFER_CONFIG" "tests/server-integration/config.toml"
-            server <- async runServer
+            server <- async $ withArgs ["--port=8081"] runServer
             (_, _, _, vault1) <- runVault 8213 "root"
             (_, _, _, vault2) <- runVault 8215 "second"
             sleep 1
             pure (server, vault1, vault2)
           do
             \(server, vault1, vault2) -> do
-              unsetEnv "COFFER_CONFIG"
               cancel server
               terminateProcess vault1
               terminateProcess vault2


### PR DESCRIPTION
## Description

Motivation:
Server port wasn't configurable. 
We want to be able specify it via `cmd line option` or `environment variable`

Solution:
Implement configuration by `cmd option`(stronger) & `env variable` for port
- in `lib`:
  - added `serverOption`
  - added lookup for env var 'COFFER_SERVER_PORT'
- in `tests -> server-integration`
  - added cmd option with 8081 port
  - added tests for port configuration (tests based on 8079 port)


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #85

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
