### PR TITLE
[#65] Make path's charset rules backend specific

### DIFF
--- a/coffer.cabal
+++ b/coffer.cabal
@@ -344,6 +344,7 @@ test-suite server-integration
       Tag.TagTest
       Tree
       Utils
+      Vault.Common
       View.ViewTest
       Paths_coffer
   hs-source-dirs:

--- a/lib/Backend.hs
+++ b/lib/Backend.hs
@@ -9,7 +9,7 @@ module Backend
 where
 
 import BackendName (BackendName)
-import Coffer.Path (DirectoryContents, EntryPath, Path)
+import Coffer.Path (DirectoryContents, EntryPath, HasPathSegments, Path)
 import Data.Aeson qualified as A
 import Entry (Entry)
 import Error (CofferError)
@@ -26,3 +26,5 @@ class (Show a, A.FromJSON a) => Backend a where
   _readEntry :: Effects r => a -> EntryPath -> Sem r (Maybe Entry)
   _listDirectoryContents :: Effects r => a -> Path -> Sem r (Maybe DirectoryContents)
   _deleteEntry :: Effects r => a -> EntryPath -> Sem r ()
+  _validatePath :: Effects r => HasPathSegments s segments
+    => a -> s -> Sem r ()

--- a/lib/Backend/Interpreter.hs
+++ b/lib/Backend/Interpreter.hs
@@ -15,3 +15,4 @@ runBackend = interpret \case
   ReadEntry (SomeBackend backend) path -> _readEntry backend path
   ListDirectoryContents (SomeBackend backend) path -> _listDirectoryContents backend path
   DeleteEntry (SomeBackend backend) path -> _deleteEntry backend path
+  ValidatePath (SomeBackend backend) path -> _validatePath backend path

--- a/lib/BackendEffect.hs
+++ b/lib/BackendEffect.hs
@@ -7,10 +7,11 @@ module BackendEffect
   , readEntry
   , writeEntry
   , listDirectoryContents
-  , deleteEntry ) where
+  , deleteEntry
+  , validatePath ) where
 
 import Backends (SomeBackend)
-import Coffer.Path (DirectoryContents, EntryPath, Path)
+import Coffer.Path (DirectoryContents, EntryPath, HasPathSegments, Path)
 import Entry (Entry)
 import Polysemy
 
@@ -27,4 +28,5 @@ data BackendEffect m a where
   -- | Once all entries are deleted from a directory, then the directory disappears
   --   (i.e. @ListDirectoryContents@ will no longer list that directory)
   DeleteEntry :: SomeBackend -> EntryPath -> BackendEffect m ()
+  ValidatePath :: HasPathSegments s segments => SomeBackend -> s -> BackendEffect m ()
 makeSem ''BackendEffect

--- a/lib/CLI/Parser.hs
+++ b/lib/CLI/Parser.hs
@@ -9,11 +9,13 @@ module CLI.Parser
   , parseFilterDate
   ) where
 
+import Backends (SupportedBackend(..), supportedBackendsMap)
 import CLI.Types
 import Coffer.Path (EntryPath, Path, QualifiedPath, mkEntryPath, mkPath, mkQualifiedPath)
 import Data.Bifunctor (first)
 import Data.Function ((&))
 import Data.Functor ((<&>))
+import Data.HashMap.Internal.Strict qualified as HS
 import Data.List qualified as List
 import Data.Map (Map)
 import Data.Map qualified as M
@@ -415,17 +417,25 @@ readFilter = do
 
 expectedQualifiedEntryPathFormat :: Pretty.Doc
 expectedQualifiedEntryPathFormat = Pretty.vsep
-  [ "Expected format is: [<backend-name>#]<entry-path>."
-  , "<backend-name> can be a string of the following characters: [a-zA-Z0-9] and symbols '-', '_', ';'."
-  , "Examples: 'vault_kv-backend#secrets/google', 'my/passwords/entry'."
-  ]
+  $ [ "Expected format is: [<backend-name>#]<entry-path>."
+    , "<backend-name> can be a string of the following characters: [a-zA-Z0-9] and symbols '-', '_', ';'."
+    , "Backend <entry-path> specifics :"
+    ]
+  <> (map bPathHelpMsg $ HS.elems supportedBackendsMap)
+  <> [ Pretty.empty
+     , "Examples: 'vault_kv-backend#secrets/google', 'my/passwords/entry'."
+     ]
 
 expectedQualifiedPathFormat :: Pretty.Doc
 expectedQualifiedPathFormat = Pretty.vsep
-  [ "Expected format is: [<backend-name>#]<path>."
-  , "<backend-name> can be a string of the following characters: [a-zA-Z0-9] and symbols '-', '_', ';'."
-  , "Examples: 'vault_kv-backend#secrets/google', 'my/passwords/mypage/'."
-  ]
+  $ [ "Expected format is: [<backend-name>#]<path>."
+    , "<backend-name> can be a string of the following characters: [a-zA-Z0-9] and symbols '-', '_', ';'."
+    , "Backend <path> specifics :"
+    ]
+  <> (map bPathHelpMsg $ HS.elems supportedBackendsMap)
+  <> [ Pretty.empty
+     , "Examples: 'vault_kv-backend#secrets/google', 'my/passwords/mypage/'."
+     ]
 
 expectedFilterFormat :: Pretty.Doc
 expectedFilterFormat = Pretty.vsep

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -23,6 +23,7 @@ module Coffer.Path
   , entryPathAsPath
   , replacePathPrefix
   , QualifiedPath (..)
+  , getPathSegments
   ) where
 
 import BackendName (BackendName, newBackendName)
@@ -247,8 +248,12 @@ instance (ToHttpApiData path, Buildable path) => ToHttpApiData (QualifiedPath pa
 -- Optics
 ----------------------------------------------------------------------------
 
-class HasPathSegments s pathSegments | s -> pathSegments where
-  pathSegments :: Iso' s pathSegments
+class
+     Each pathSegments pathSegments PathSegment PathSegment
+  => HasPathSegments s pathSegments
+  |  s -> pathSegments
+  where
+    pathSegments :: Iso' s pathSegments
 instance HasPathSegments Path [PathSegment] where
   pathSegments = iso unPath Path
 instance HasPathSegments EntryPath (NonEmpty PathSegment) where
@@ -257,6 +262,11 @@ instance HasPathSegments EntryPath (NonEmpty PathSegment) where
 ----------------------------------------------------------------------------
 -- Helpers
 ----------------------------------------------------------------------------
+
+getPathSegments
+  :: HasPathSegments s segments
+  => s -> [Text]
+getPathSegments path = path ^.. pathSegments . each . to unPathSegment
 
 -- | Append an item to the end of a list.
 appendNE :: [a] -> a -> NonEmpty a

--- a/lib/Coffer/Path.hs
+++ b/lib/Coffer/Path.hs
@@ -6,7 +6,6 @@ module Coffer.Path
   ( PathSegment
   , unPathSegment
   , mkPathSegment
-  , pathSegmentAllowedCharacters
   , DirectoryContents(..)
   , directoryNames
   , entryNames
@@ -64,12 +63,9 @@ mkPathSegment :: Text -> Either Text PathSegment
 mkPathSegment segment
   | T.null segment =
       Left "Path segments must contain at least 1 character"
-  | T.any (`notElem` pathSegmentAllowedCharacters) segment =
-      Left $ "Path segments can only contain the following characters: '" <> T.pack pathSegmentAllowedCharacters <> "'"
+  | '#' `elem` T.unpack segment =
+      Left $ "Path segments can't contain the following characters: '#'"
   | otherwise = Right $ UnsafeMkPathSegment segment
-
-pathSegmentAllowedCharacters :: [Char]
-pathSegmentAllowedCharacters = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ "-_"
 
 data DirectoryContents = DirectoryContents
   { dcDirectoryNames :: [PathSegment]

--- a/lib/Config.hs
+++ b/lib/Config.hs
@@ -6,7 +6,7 @@ module Config where
 
 import Backend (Backend(..))
 import BackendName (BackendName, backendNameCodec)
-import Backends (SomeBackend(..), backendPackedCodec)
+import Backends (SomeBackend(..), someBackendCodec)
 import Data.Foldable (toList)
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HS
@@ -26,7 +26,7 @@ makeSingleBackendConfig (SomeBackend backend) = Config (HS.singleton (_name back
 configCodec :: TomlCodec Config
 configCodec = Config
   <$> Toml.dimap toList listToHs
-  (Toml.list backendPackedCodec "backend") .= backends
+  (Toml.list someBackendCodec "backend") .= backends
   <*> backendNameCodec "main_backend" .= mainBackend
   where
     listToHs list = HS.fromList $ fmap (\y@(SomeBackend x) -> (_name x, y)) list

--- a/lib/Error.hs
+++ b/lib/Error.hs
@@ -9,7 +9,7 @@ module Error
   ) where
 
 import BackendName (BackendName)
-import Coffer.Path (EntryPath, Path)
+import Coffer.Path (EntryPath, Path, PathSegment, unPathSegment)
 import Data.Text (Text)
 import Entry (BadEntryTag, BadFieldName)
 import Fmt (Buildable(build))
@@ -24,6 +24,10 @@ data CofferError where
   BadFieldNameError :: BadFieldName -> CofferError
   BadMasterFieldName :: Text -> BadFieldName -> CofferError
   BadEntryTagError :: BadEntryTag -> CofferError
+  InvalidPathSegment
+    :: PathSegment
+    -> Text -- ^ Backend-specific error message
+    -> CofferError
 
 -- | Type class for backend errors.
 class (Buildable err) => BackendError err
@@ -54,6 +58,13 @@ instance Buildable CofferError where
       |]
     BackendNotFound backendName ->
       [int|s|Backend with name '#{backendName}' not found.|]
+    InvalidPathSegment segment errMsg ->
+      [int|s|
+        Invalid path segment for target backend:
+        Got: #s{unPathSegment segment}.
+
+        #{errMsg}
+      |]
     BadFieldNameError err -> build err
     BadMasterFieldName name err ->
       [int|s|

--- a/tests/golden/common/common.bats
+++ b/tests/golden/common/common.bats
@@ -9,22 +9,13 @@ load '../helpers/bats-assert/load'
 load '../helpers'
 
 @test "bad path" {
-  run coffer view "$(echo -e "bad\npath")"
+  run coffer view "$(echo -e "bad#path#")"
 
   assert_failure
   assert_output --partial - <<EOF
-Invalid path: "bad\npath".
-Path segments can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
-EOF
-}
-
-@test "bad entry path" {
-  run coffer create "$(echo -e "bad/entry\npath")"
-
-  assert_failure
-  assert_output --partial - <<EOF
-Invalid entry path: "bad/entry\npath".
-Path segments can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
+Parser error:
+Too many # literals.
+Expected format is: [<backend-name>#]<path>.
 EOF
 }
 

--- a/tests/golden/common/common.bats
+++ b/tests/golden/common/common.bats
@@ -56,6 +56,10 @@ EOF
 Invalid qualified entry path format: "back#/path#\n\nsmth".
 Expected format is: [<backend-name>#]<entry-path>.
 <backend-name> can be a string of the following characters: [a-zA-Z0-9] and symbols '-', '_', ';'.
+Backend <entry-path> specifics :
+Vault Kv paths can contain only the following characters:
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
+
 Examples: 'vault_kv-backend#secrets/google', 'my/passwords/entry'.
 
 Parser error:
@@ -72,11 +76,16 @@ EOF
 Invalid qualified path format: "back#/path#\n\nsmth".
 Expected format is: [<backend-name>#]<path>.
 <backend-name> can be a string of the following characters: [a-zA-Z0-9] and symbols '-', '_', ';'.
+Backend <path> specifics :
+Vault Kv paths can contain only the following characters:
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
+
 Examples: 'vault_kv-backend#secrets/google', 'my/passwords/mypage/'.
 
 Parser error:
 Too many # literals.
 Expected format is: [<backend-name>#]<path>.
+
 EOF
 }
 

--- a/tests/golden/vault/common.bats
+++ b/tests/golden/vault/common.bats
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+#!/usr/bin/env bats
+
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+load '../helpers'
+
+@test "vault bad path" {
+  run coffer view "$(echo -e "bad\npath")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+Invalid path segment for target backend:
+Got: "bad\npath".
+
+Path segments for Vault KV can only contain the following characters:
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'.
+EOF
+}
+
+@test "vault bad entry path" {
+  run coffer create "$(echo -e "bad/entry\npath")"
+
+  assert_failure
+  assert_output --partial - <<EOF
+Invalid path segment for target backend:
+Got: "entry\npath".
+
+Path segments for Vault KV can only contain the following characters:
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'.
+EOF
+}

--- a/tests/server-integration/Common/Common.hs
+++ b/tests/server-integration/Common/Common.hs
@@ -124,7 +124,7 @@ unit_incorrect_tag_name_fromHttpApiData = cofferTest do
 unit_incorrect_path_segment_fromHttpApiData :: IO ()
 unit_incorrect_path_segment_fromHttpApiData = cofferTest do
 
-  try @HttpException ( createEntry "entry:." )
+  try @HttpException ( createEntry "entry#" )
     >>= unwrapStatusCodeError \response bs -> do
-      bs @?= "Error parsing query parameter path failed: Path segments can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'"
+      bs @?= "Error parsing query parameter path failed: Path segments can't contain the following characters: '#'"
       responseStatus response @?= status400

--- a/tests/server-integration/Common/Common.hs
+++ b/tests/server-integration/Common/Common.hs
@@ -3,8 +3,7 @@
 -- SPDX-License-Identifier: MPL-2.0
 
 module Common.Common
-  ( unit_incorrect_backend_name
-  , unit_incorrect_field_name_fromJSONKey
+  ( unit_incorrect_field_name_fromJSONKey
   , unit_incorrect_field_name_fromHttpApiData
   , unit_incorrect_tag_name_fromJSON
   , unit_incorrect_tag_name_fromHttpApiData
@@ -12,47 +11,13 @@ module Common.Common
   ) where
 
 import Control.Exception
-import Data.Aeson (encode)
 import Data.Aeson.QQ.Simple (aesonQQ)
-import Data.ByteString.Lazy qualified as LBS
 import Data.Text
 import Network.HTTP.Client (Response(responseStatus))
 import Network.HTTP.Req
 import Network.HTTP.Types (status400)
 import Test.Tasty.HUnit
 import Utils
-
-unit_incorrect_backend_name :: IO ()
-unit_incorrect_backend_name = cofferTest do
-  try @HttpException
-    (executeCommandWithHeader
-        errHeader
-        POST
-        ["create"]
-        (ReqBodyJson emptyNewEntry)
-        ignoreResponse
-        ("path" =: ("entry" :: Text))
-      ) >>= unwrapStatusCodeError \response bs -> do
-        bs @?= "Error parsing header Coffer-Backend failed: Error in $.name: Backend name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
-        responseStatus response @?= status400
-    where
-    emptyNewEntry =
-      [aesonQQ|
-        {
-          "fields": { },
-          "tags": []
-        }
-      |]
-    errHeader = LBS.toStrict . encode $
-      [aesonQQ|
-          {
-            "type" : "vault-kv",
-            "name" : "vault-local#",
-            "address" : "localhost:8212",
-            "mount" : "secret",
-            "token" : "root"
-          }
-      |]
 
 unit_incorrect_field_name_fromJSONKey :: IO()
 unit_incorrect_field_name_fromJSONKey = cofferTest do

--- a/tests/server-integration/Vault/Common.hs
+++ b/tests/server-integration/Vault/Common.hs
@@ -1,0 +1,86 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module Vault.Common
+  ( unit_vault_incorrect_path_segment_fromHttpApiData
+  , unit_vault_incorrect_backend_name
+  ) where
+
+import Control.Exception
+import Data.Aeson (encode)
+import Data.Aeson qualified as A
+import Data.Aeson.QQ.Simple (aesonQQ)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Network.HTTP.Client (Response(..))
+import Network.HTTP.Req
+import Network.HTTP.Types (status400, status500)
+import Test.Tasty.HUnit ((@?=))
+import Utils (cofferTest, executeCommandWithHeader, processStatusCodeError, unwrapStatusCodeError)
+
+unit_vault_incorrect_backend_name :: IO ()
+unit_vault_incorrect_backend_name = cofferTest do
+  try @HttpException
+    (executeCommandWithHeader
+        errHeader
+        POST
+        ["create"]
+        (ReqBodyJson emptyNewEntry)
+        ignoreResponse
+        ("path" =: ("entry" :: Text))
+      ) >>= unwrapStatusCodeError \response bs -> do
+        bs @?= "Error parsing header Coffer-Backend failed: Error in $.name: Backend name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
+        responseStatus response @?= status400
+    where
+    errHeader = LBS.toStrict . encode $
+      [aesonQQ|
+          {
+            "type" : "vault-kv",
+            "name" : "vault-local#",
+            "address" : "localhost:8212",
+            "mount" : "secret",
+            "token" : "root"
+          }
+      |]
+
+unit_vault_incorrect_path_segment_fromHttpApiData :: IO ()
+unit_vault_incorrect_path_segment_fromHttpApiData = cofferTest do
+
+  try @HttpException
+    (executeCommandWithHeader
+        header
+        POST
+        ["create"]
+        (ReqBodyJson emptyNewEntry)
+        ignoreResponse
+        ("path" =: ("entry:." :: Text)))
+    >>= processStatusCodeError status500
+      [aesonQQ|
+        [
+          {
+            "error" : "Invalid path segment for target backend:\nGot: \"entry:.\".\n\nPath segments for Vault KV can only contain the following characters:\n'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'.",
+            "code"  : 0
+          }
+        ]
+      |]
+  where
+    header = LBS.toStrict . encode $
+      [aesonQQ|
+          {
+            "type" : "vault-kv",
+            "name" : "vault-local",
+            "address" : "localhost:8212",
+            "mount" : "secret",
+            "token" : "root"
+          }
+      |]
+
+emptyNewEntry :: A.Value
+emptyNewEntry =
+      [aesonQQ|
+        {
+          "fields": { },
+          "tags": []
+        }
+      |]


### PR DESCRIPTION
## Description

### Motivation
We wanted to validate paths not on Path lvl, but on Backend lvl (So each backend validates paths)

### Solution
- Remove check for allowed symbols
- Added check for not containing '#'
- Added new Effect of `Backend` - `validatePath`
- Added validation for paths in `Backend.Commands`
     So it's now cmd responsibility to check if path is valid lies on cmd
- Updated error msg - now they contain info about specific backend
- Added new backend specific tests

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #65

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
