### PR TITLE
[#119] Change set-field Web-API

### DIFF
--- a/lib/Entry.hs
+++ b/lib/Entry.hs
@@ -137,6 +137,12 @@ instance A.FromJSON FieldVisibility where
     "private" -> pure Private
     other -> fail $ "expecting either 'public' or 'private', but found: '" <> T.unpack other <> "'"
 
+instance FromHttpApiData FieldVisibility where
+  parseUrlPiece = \case
+    "public"  -> Right Public
+    "private" -> Right Private
+    other     -> Left $ "expecting either 'public' or 'private', but found: '" <> other <> "'"
+
 newtype FieldContents = FieldContents { unFieldContents :: Text }
   deriving stock (Show, Eq, Ord)
   deriving newtype (Hashable, A.FromJSON, A.ToJSON, A.FromJSONKey, A.ToJSONKey)

--- a/lib/Web/API.hs
+++ b/lib/Web/API.hs
@@ -30,12 +30,15 @@ type API
     :<|> "set-field"
       :> RequiredParam "path" EntryPath
       :> RequiredParam "field" FieldName
-      :>
-        (    "private" :> Post '[JSON] Entry
-        :<|> "public"  :> Post '[JSON] Entry
-        :<|> ReqBody '[JSON] (Maybe FieldContents)
-          :> Post '[JSON] Entry
-        )
+      :> OptionalParam "visibility" FieldVisibility
+      :> ReqBody '[JSON] FieldContents
+      :> Post '[JSON] Entry
+
+    :<|> "set-field-visibility"
+      :> RequiredParam "path" EntryPath
+      :> RequiredParam "field" FieldName
+      :> ReqBody '[JSON] FieldVisibility
+      :> Post '[JSON] Entry
 
     :<|> "delete-field"
       :> RequiredParam "path" EntryPath

--- a/lib/Web/API.hs
+++ b/lib/Web/API.hs
@@ -37,8 +37,9 @@ type API
     :<|> "set-field-visibility"
       :> RequiredParam "path" EntryPath
       :> RequiredParam "field" FieldName
-      :> ReqBody '[JSON] FieldVisibility
-      :> Post '[JSON] Entry
+      :> (    "public"  :> Post '[JSON] Entry
+         :<|> "private" :> Post '[JSON] Entry
+         )
 
     :<|> "delete-field"
       :> RequiredParam "path" EntryPath

--- a/lib/Web/Server.hs
+++ b/lib/Web/Server.hs
@@ -129,19 +129,15 @@ makeServer
   :: (SomeBackend -> (forall a. Command a -> Handler a))
   -> Server API
 makeServer run backend
-  =    view   (run backend)
-  :<|> create (run backend)
-  :<|>
-    (\txt fkey ->
-         private (run backend) txt fkey
-    :<|> public  (run backend) txt fkey
-    :<|> set     (run backend) txt fkey
-    )
-  :<|> deleteField (run backend)
-  :<|> find'       (run backend)
-  :<|> rename      (run backend)
-  :<|> copy'       (run backend)
-  :<|> delete'     (run backend)
+  =    view               (run backend)
+  :<|> create             (run backend)
+  :<|> setField           (run backend)
+  :<|> setFieldVisibility (run backend)
+  :<|> deleteField        (run backend)
+  :<|> find'              (run backend)
+  :<|> rename             (run backend)
+  :<|> copy'              (run backend)
+  :<|> delete'            (run backend)
   :<|>
     (\path tag' ->
          tag (run backend) path tag' False
@@ -202,44 +198,33 @@ create run coPath coForce (NewEntry coFields coTags) =
 
     pretty = resultToText buildCreateError
 
-private
+setFieldVisibility
   :: (forall a. Command a -> Handler a)
   -> EntryPath
   -> FieldName
+  -> FieldVisibility
   -> Handler Entry
-private run sfoPath sfoFieldName  = do
+setFieldVisibility run path field visibility =
   run (CmdSetField SetFieldOptions
-    { sfoQPath = QualifiedPath Nothing sfoPath
-    , sfoFieldName
+    { sfoQPath = QualifiedPath Nothing path
+    , sfoFieldName = field
     , sfoFieldContents = Nothing
-    , sfoVisibility = Just Private
+    , sfoVisibility = Just visibility
     }) >>= handleSetFieldResult
 
-public
+setField
   :: (forall a. Command a -> Handler a)
   -> EntryPath
   -> FieldName
+  -> Maybe FieldVisibility
+  -> FieldContents
   -> Handler Entry
-public run sfoPath sfoFieldName  =
+setField run path field visibility contents =
   run (CmdSetField SetFieldOptions
-    { sfoQPath = QualifiedPath Nothing sfoPath
-    , sfoFieldName
-    , sfoFieldContents = Nothing
-    , sfoVisibility = Just Public
-    }) >>= handleSetFieldResult
-
-set
-  :: (forall a. Command a -> Handler a)
-  -> EntryPath
-  -> FieldName
-  -> Maybe FieldContents
-  -> Handler Entry
-set run sfoPath sfoFieldName sfoFieldContents =
-  run (CmdSetField SetFieldOptions
-    { sfoQPath = QualifiedPath Nothing sfoPath
-    , sfoFieldName
-    , sfoFieldContents = sfoFieldContents
-    , sfoVisibility = Nothing
+    { sfoQPath = QualifiedPath Nothing path
+    , sfoFieldName = field
+    , sfoFieldContents = Just contents
+    , sfoVisibility = visibility
     }) >>= handleSetFieldResult
 
 deleteField

--- a/lib/Web/Server.hs
+++ b/lib/Web/Server.hs
@@ -125,13 +125,6 @@ reportErrors io = do
     Right (Right a) -> do
       return a
 
--- setFieldVisibility
---   :: (forall a. Command a -> Handler a)
---   -> Bool
---   -> EntryPath
---   -> FieldName
---   -> Handler Entry
-
 makeServer
   :: (SomeBackend -> (forall a. Command a -> Handler a))
   -> Server API

--- a/lib/Web/Server.hs
+++ b/lib/Web/Server.hs
@@ -125,6 +125,13 @@ reportErrors io = do
     Right (Right a) -> do
       return a
 
+-- setFieldVisibility
+--   :: (forall a. Command a -> Handler a)
+--   -> Bool
+--   -> EntryPath
+--   -> FieldName
+--   -> Handler Entry
+
 makeServer
   :: (SomeBackend -> (forall a. Command a -> Handler a))
   -> Server API
@@ -132,7 +139,10 @@ makeServer run backend
   =    view               (run backend)
   :<|> create             (run backend)
   :<|> setField           (run backend)
-  :<|> setFieldVisibility (run backend)
+  :<|> (\path field->
+            setFieldVisibility (run backend) path field Public
+       :<|> setFieldVisibility (run backend) path field Private
+       )
   :<|> deleteField        (run backend)
   :<|> find'              (run backend)
   :<|> rename             (run backend)

--- a/tests/server-integration/Common/Common.hs
+++ b/tests/server-integration/Common/Common.hs
@@ -86,7 +86,7 @@ unit_incorrect_field_name_fromHttpApiData :: IO()
 unit_incorrect_field_name_fromHttpApiData = cofferTest do
   createEntry "entry"
 
-  try @HttpException ( setField "entry" "fieldname:." "contents" )
+  try @HttpException ( setField "entry" "fieldname:." Nothing "contents" )
     >>= unwrapStatusCodeError \response bs -> do
       bs @?= "Error parsing query parameter field failed: Field name can only contain the following characters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_;'"
       responseStatus response @?= status400

--- a/tests/server-integration/CopyAndRename/Common.hs
+++ b/tests/server-integration/CopyAndRename/Common.hs
@@ -150,7 +150,7 @@ copyOrRenameCreateErrors copy = cofferTest do
 copyOrRenameUpdatesOnlyEntrysModificationTime :: Bool -> IO ()
 copyOrRenameUpdatesOnlyEntrysModificationTime copy = cofferTest do
   createEntry "entry"
-  response <- setField "entry" "field" "contents"
+  response <- setField "entry" "field" Nothing "contents"
   let modifiedDate = responseBody response ^?! key "dateModified"
 
   t1 <- getCurrentTime

--- a/tests/server-integration/DeleteField/DeleteFieldTest.hs
+++ b/tests/server-integration/DeleteField/DeleteFieldTest.hs
@@ -39,7 +39,7 @@ executeDeleteField path field =
 unit_delete_field :: IO ()
 unit_delete_field = cofferTest do
   createEntry "entry"
-  void $ setField "entry" "field" "contents"
+  void $ setField "entry" "field" Nothing "contents"
 
   response <- executeDeleteField "entry" "field"
 
@@ -79,7 +79,7 @@ unit_delete_field_field_not_found = cofferTest do
 unit_delete_field_updates_entry's_modification_time :: IO ()
 unit_delete_field_updates_entry's_modification_time = cofferTest do
   createEntry "entry"
-  response <- setField "entry" "field" "contents"
+  response <- setField "entry" "field" Nothing "contents"
 
   let oldModificationTime = responseBody response ^?! key "dateModified"
 

--- a/tests/server-integration/SetField/SetFieldTest.hs
+++ b/tests/server-integration/SetField/SetFieldTest.hs
@@ -122,8 +122,8 @@ unit_set_field_visibility = cofferTest do
   createEntry "dir/entry"
   void $ setField "dir/entry" "private-field" Nothing "contents"
   void $ setField "dir/entry" "public-field" Nothing "contents"
-  changeFieldVisibility "dir/entry" "private-field" False
-  changeFieldVisibility "dir/entry" "public-field" True
+  changeFieldVisibility "dir/entry" "private-field" "private"
+  changeFieldVisibility "dir/entry" "public-field" "public"
 
   response <-
     executeCommand

--- a/tests/server-integration/Tag/TagTest.hs
+++ b/tests/server-integration/Tag/TagTest.hs
@@ -102,7 +102,7 @@ unit_tag_duplicate_tag = cofferTest do
 unit_tag_updates_only_entry's_modification_time :: IO ()
 unit_tag_updates_only_entry's_modification_time = cofferTest do
   createEntry "entry"
-  response <- setField "entry" "field" "contents"
+  response <- setField "entry" "field" Nothing  "contents"
   let modificationTime = responseBody response ^?! key "dateModified"
   t1 <- getCurrentTime
   response <- addOrRemoveTag POST "entry" "tag"

--- a/tests/server-integration/Utils.hs
+++ b/tests/server-integration/Utils.hs
@@ -118,12 +118,12 @@ setField path name public contents =
   where
     visibility = boolToVisibility <$> public
 
-changeFieldVisibility :: Text -> Text -> Bool -> IO ()
-changeFieldVisibility path field public = void $
+changeFieldVisibility :: Text -> Text -> Text -> IO ()
+changeFieldVisibility path field visibility = void $
   executeCommand
     POST
-    ["set-field-visibility"]
-    (ReqBodyJson $ String $ boolToVisibility public)
+    ["set-field-visibility", visibility]
+    NoReqBody
     ignoreResponse
     ( mconcat
         [ "path" =: path

--- a/tests/server-integration/View/ViewTest.hs
+++ b/tests/server-integration/View/ViewTest.hs
@@ -16,8 +16,8 @@ import Utils
 unit_view_an_entry :: IO ()
 unit_view_an_entry = cofferTest do
   createEntry "dir/entry"
-  void $ setField "dir/entry" "public-field" "contents"
-  void $ setField "dir/entry" "private-field" "multiline\ncontents"
+  void $ setField "dir/entry" "public-field" Nothing "contents"
+  void $ setField "dir/entry" "private-field" Nothing "multiline\ncontents"
   changeFieldVisibility "dir/entry" "private-field" False
 
   response <-

--- a/tests/server-integration/View/ViewTest.hs
+++ b/tests/server-integration/View/ViewTest.hs
@@ -18,7 +18,7 @@ unit_view_an_entry = cofferTest do
   createEntry "dir/entry"
   void $ setField "dir/entry" "public-field" Nothing "contents"
   void $ setField "dir/entry" "private-field" Nothing "multiline\ncontents"
-  changeFieldVisibility "dir/entry" "private-field" False
+  changeFieldVisibility "dir/entry" "private-field" "private"
 
   response <-
     executeCommand


### PR DESCRIPTION
## Description

Problem: `set-field` route was used both for changing visibility
and setting new fields. This resulted in additional handling of the
situation where both field contents and visibility option are missing.

Solution: require contents for setting field and allow changing
visibility for convenience. Add `set-field-visibility` request
which modifies only visibility.

### Question?
Currently in `set-field-visibility` I pass the value in the body of the request.
Maybe it would be better to pass it in the request string itself:

```
set-field-visibility/entry-path/field/private
```

I don't know.

## Related issue(s)
Fixed part of #119. Refactor of CLI API still needed.

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

<!-- TODO: uncomment this after the first release. -->
<!--
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible
-->

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
